### PR TITLE
Replace cax-process and add runconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .project
 .pydevproject
 __pycache__
+*.dbtoken
 

--- a/outsource/Config.py
+++ b/outsource/Config.py
@@ -1,11 +1,7 @@
 import re
 import os
 import time
-import getpass
-#from outsource.rundb import DB
-
 import configparser
-import threading
 
 dir_raw = '/xenon/xenon1t/raw'
 
@@ -26,14 +22,12 @@ class Config():
         if not Config.instance:
             Config.instance = Config.__Config()
             
-    
+
     def __getattr__(self, name):
         return getattr(self.instance, name)
     
     
     class __Config(configparser.ConfigParser):
-        
-        _run_id = None
         
         def __init__(self):
             
@@ -45,10 +39,7 @@ class Config():
                 self.readfp(open(config_file_path), 'r')
             except FileNotFoundError as e:
                 raise RuntimeError('Unable to open %s. Please see the README for an example configuration' %(config_file_path)) from e
-    
-            self._run_id = str(time.time())
-            self._run_id = re.sub('\..*', '', self._run_id)
-    
+
    
         def base_dir(self):
             return os.path.dirname(__file__)
@@ -58,40 +49,6 @@ class Config():
         
         def runs_dir(self):
             return os.path.join(self.work_dir(), 'runs')
-        
-        def generated_dir(self):
-            return os.path.join(self.work_dir(), 'generated', self._run_id)
-        
-        def pax_version(self):
-            return 'v' + self.get('Outsource', 'pax_version')
-        
+
         def pegasus_path(self):
             return self.get('Outsource', 'pegasus_path')
-    
-        def raw_dir(self):
-            return os.path.join(dir_raw, self._run_name)
-    
-        def workflow_title(self):
-            return os.path.join(self.runs_dir(), self._run_id)
-   
-        def run_id(self):
-            return self._run_id
-
-        def set_run_id(self, run_id):
-            '''
-            Update the run id - this should be done early in the lifetime of the module's lifetime
-            as other methods depends on the run id value
-            '''
-            self._run_id = run_id
-
-        def set_run_name(self, run_name):
-            self._run_name = run_name
-
-
-class ConfigDB(Config):
-    """Object that uses run identifier and RunDB API to make config"""
-
-    def __init__(self, run_id, detector='tpc'):
-        #self._run_id = DB.get_name(run_id, detector)
-        pass
-

--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -85,10 +85,6 @@ class Outsource:
 
         self._generate_dax()
 
-        # TODO temporary
-        json_file = os.path.join(self.config.generated_dir, "rundoc.json")
-        write_json_file(self.config.run_doc,json_file)
-
         self._plan_and_submit()
     
     
@@ -170,6 +166,7 @@ class Outsource:
                              'False')
             job.uses(determine_rse, link=Link.INPUT)
             job.uses(json_infile, link=Link.INPUT)
+            job.uses(paxify, link=Link.INPUT)
             #job.uses(job_output, link=Link.OUTPUT)
             dax.addJob(job)
         

--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -10,7 +10,6 @@ import sys
 
 from outsource.Shell import Shell
 from outsource.Config import Config
-from outsource.rundb import DB
 
 config = Config()
 logger = logging.getLogger("my_logger")
@@ -33,29 +32,14 @@ class Outsource:
         'SURFSARA_USERDISK': '',
     }
 
-    #def __init__(self, config):
-    #    """Take a Config object as input to make the workflow"""
-    #
-    #    # TODO config stuff (see above also)
-    #    self.config = config
-    
-    # information from the run database
-    _run_info = None
-    
-    
-    def __init__(self, detector, name, force_rerun = False, update_run_db = False):
+    def __init__(self, runcfg):
         '''
-        Creates a new Outsource object. Specifying a detector and name is required.
+        Creates a new Outsource object. Specifying a RunConfig object required.
         '''
-        if not detector:
-            raise RuntimeError('Detector is a required parameter')
-        if not name:
-            raise RuntimeError('Name is a required parameter')
-        self._detector = detector
-        self._name = name
-        self._force_rerun = force_rerun
-        self._force_update_run_db = update_run_db
-        self.config = config
+        if not runcfg:
+            raise RuntimeError('A RunConfig is required')
+        # TODO there's likely going to be some confusion between the two configs here
+        self.config = runcfg
 
         # logger
         console = logging.StreamHandler()
@@ -72,15 +56,9 @@ class Outsource:
         logger.addHandler(console)
 
         # environment for subprocesses
-        os.environ['X509_USER_PROXY'] = os.path.join(os.environ['HOME'], 'user_cert')
+        os.environ['X509_USER_PROXY'] = self.config.x509_proxy
 
-        # update run id, this is currently derived from detector and name
-        self.config.set_run_id(detector + '__' + name)
-        self.config.set_run_name(name)
-        
-        db = DB()
-        self._run_info = db.get_run(name, detector)
-        
+        #
 
     def submit_workflow(self):
         '''
@@ -88,17 +66,17 @@ class Outsource:
         '''
 
         # does workflow already exist?
-        if os.path.exists(self.config.workflow_title()):
-            logger.error("Workflow already exists at {path}. Exiting.".format(path=self.config.workflow_title()))
+        if os.path.exists(self.config.workflow_path):
+            logger.error("Workflow already exists at {path}. Exiting.".format(path=self.config.workflow_path))
             return
 
         # work dirs
         try:
-            os.makedirs(self.config.generated_dir(), 0o755)
+            os.makedirs(self.config.generated_dir, 0o755)
         except OSError:
             pass
         try:
-            os.makedirs(self.config.runs_dir(), 0o755)
+            os.makedirs(config.runs_dir(), 0o755)
         except OSError:
             pass
         
@@ -106,6 +84,11 @@ class Outsource:
         self._validate_x509_proxy()
 
         self._generate_dax()
+
+        # TODO temporary
+        json_file = os.path.join(self.config.generated_dir, "rundoc.json")
+        write_json_file(self.config.run_doc,json_file)
+
         self._plan_and_submit()
     
     
@@ -125,17 +108,17 @@ class Outsource:
         dax = ADAG('xenonnt')
         
         # event callouts
-        dax.invoke('start',  self.config.base_dir() + '/workflow/events/wf-start')
-        dax.invoke('at_end',  self.config.base_dir() + '/workflow/events/wf-end')
+        dax.invoke('start',  config.base_dir() + '/workflow/events/wf-start')
+        dax.invoke('at_end',  config.base_dir() + '/workflow/events/wf-end')
         
         # Add executables to the DAX-level replica catalog
         wrapper = Executable(name='run-pax.sh', arch='x86_64', installed=False)
-        wrapper.addPFN(PFN('file://' + self.config.base_dir() + '/workflow/run-pax.sh', 'local'))
+        wrapper.addPFN(PFN('file://' + config.base_dir() + '/workflow/run-pax.sh', 'local'))
         wrapper.addProfile(Profile(Namespace.CONDOR, 'requirements', requirements))
         wrapper.addProfile(Profile(Namespace.PEGASUS, 'clusters.size', 1))
         dax.addExecutable(wrapper)
         
-        pax_version = self.config.pax_version()
+        pax_version = self.config.pax_version
 
         # determine_rse - a helper for the job to determine where to pull data from
         determine_rse = File('determine_rse.py')
@@ -143,9 +126,11 @@ class Outsource:
         dax.addFile(determine_rse)
 
         # json file for the run
-        self._write_run_info_json(os.path.join(config.generated_dir(), 'run_info.json'))
+        #self._write_run_info_json(os.path.join(config.generated_dir(), 'run_info.json'))
+        json_file = os.path.join(self.config.generated_dir, "run_info.json")
+        write_json_file(self.config.run_doc, json_file)
         json_infile = File('run_info.json')
-        json_infile.addPFN(PFN('file://' + os.path.join(config.generated_dir(), 'run_info.json'), 'local'))
+        json_infile.addPFN(PFN('file://' + os.path.join(self.config.generated_dir, 'run_info.json'), 'local'))
         dax.addFile(json_infile)
         
         # add jobs, one for each input file
@@ -163,7 +148,8 @@ class Outsource:
                 
             stash_gridftp_url = None
             if zip_props['stash_available']:
-                stash_gridftp_url = 'gsiftp://gridftp.grid.uchicago.edu:2811/cephfs/srm' + config.raw_dir() + '/' + zip_file 
+                stash_gridftp_url = 'gsiftp://gridftp.grid.uchicago.edu:2811/cephfs/srm' + \
+                                    self.config.input_location + '/' + zip_file
         
             # output files
             job_output = File(zip_file + '.OUTPUT')
@@ -171,14 +157,11 @@ class Outsource:
             # Add job
             job = Job(name='run-pax.sh')
             # Note that any changes to this argument list, also means run-pax.sh has to be updated
-            job.addArguments(self.config.run_id(), 
+            job.addArguments(self.config.name,
                              zip_file,
                              str(file_rucio_dataset),
                              str(stash_gridftp_url),
-                             socket.gethostname(),
                              pax_version,
-                             "n/a",
-                             str(1),
                              'False')
             job.uses(determine_rse, link=Link.INPUT)
             job.uses(json_infile, link=Link.INPUT)
@@ -186,7 +169,7 @@ class Outsource:
             dax.addJob(job)
         
         # Write the DAX to stdout
-        f = open(os.path.join(self.config.generated_dir(), 'dax.xml'), 'w')
+        f = open(os.path.join(self.config.generated_dir, 'dax.xml'), 'w')
         dax.writeXML(f)
         f.close()
        
@@ -196,11 +179,11 @@ class Outsource:
         Call out to plan-env-helper.sh to start the workflow
         '''
         
-        cmd = ' '.join([os.path.join(self.config.base_dir(), 'workflow/plan-env-helper.sh'),
-                        self.config.base_dir(),
-                        self.config.generated_dir(),
-                        self.config.runs_dir(),
-                        self.config.run_id()])
+        cmd = ' '.join([os.path.join(config.base_dir(), 'workflow/plan-env-helper.sh'),
+                        config.base_dir(),
+                        self.config.generated_dir,
+                        config.runs_dir(),
+                        self.config.workflow_id])
         shell = Shell(cmd, log_cmd = False, log_outerr = True)
         shell.run()
        
@@ -219,29 +202,6 @@ class Outsource:
                                %(valid_hours, min_valid_hours))
 
 
-    def _write_run_info_json(self, json_file):
-        '''
-        take a run info structure, write to json file
-        '''
-
-        with open(json_file, "w") as f:
-            # fix run_info so that all '|' become '.' in json
-            fixed_run_info = self._fix_keys(self._run_info)
-            json.dump(fixed_run_info, f)
-        if os.stat(json_file).st_uid == os.getuid():
-            os.chmod(json_file, 0o777)
-        return json_file
-
-
-    def _fix_keys(self,  dictionary):
-        for key, value in dictionary.items():
-            if type(value) in [type(dict())]:
-                dictionary[key] = self._fix_keys(value)
-            if '|' in key:
-                dictionary[key.replace('|', '.')] = dictionary.pop(key)
-        return dictionary
-  
- 
     def _data_find_locations(self):
         '''
         Check Rucio and other locations to determine where input files exist
@@ -251,7 +211,7 @@ class Outsource:
         rses = []
         stash_raw_path = None
         
-        for d in self._run_info['data']:
+        for d in self.config.run_doc['data']:
             if d['host'] == 'rucio-catalogue' and d['status'] == 'transferred':
                     rucio_dataset = d['location']
         
@@ -268,9 +228,9 @@ class Outsource:
                 logger.warning("Problem finding Rucio RSEs")
                 
         # also check local dir (which is available via GridFTP)
-        if os.path.exists(config.raw_dir()):
+        if os.path.exists(self.config.input_location):
             # also make sure the dir contains some zip files?
-            stash_raw_path = config.raw_dir()
+            stash_raw_path = self.config.input_location
             
         return rucio_dataset, rses, stash_raw_path
     
@@ -332,6 +292,28 @@ class Outsource:
         final_expr = ' || '.join(exprs)
         logger.info('Site expression from RSEs list: ' + final_expr)
         return final_expr
+
+
+# This should be temporary hopefully, but just to get things working now
+def write_json_file(doc, output):
+    # take a run doc, write to json file
+    with open(output, "w") as f:
+        # fix doc so that all '|' become '.' in json
+        fixed_doc = fix_keys(doc)
+        json.dump(fixed_doc, f)
+
+    if os.stat(output).st_uid == os.getuid():
+        os.chmod(output, 0o777)
+
+
+def fix_keys(dictionary):
+    # Need this due to mongoDB syntax issues, I think
+    for key, value in dictionary.items():
+        if type(value) in [type(dict())]:
+            dictionary[key] = fix_keys(value)
+        if '|' in key:
+            dictionary[key.replace('|', '.')] = dictionary.pop(key)
+    return dictionary
 
 
 if __name__ == '__main__':

--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -125,6 +125,11 @@ class Outsource:
         determine_rse.addPFN(PFN('file://' + os.path.join(config.base_dir(), 'workflow/determine_rse.py'), 'local'))
         dax.addFile(determine_rse)
 
+        # paxify is what processes the data. Gets called by the executable run-pax.sh
+        paxify = File('paxify.py')
+        paxify.addPFN(PFN('file://' + os.path.join(config.base_dir(), 'workflow/paxify.py'), 'local'))
+        dax.addFile(paxify)
+
         # json file for the run
         #self._write_run_info_json(os.path.join(config.generated_dir(), 'run_info.json'))
         json_file = os.path.join(self.config.generated_dir, "run_info.json")

--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -153,7 +153,7 @@ class Outsource:
                                     self.config.input_location + '/' + zip_file
         
             # output files
-            job_output = File(zip_file + '.OUTPUT')
+            job_output = File(zip_file.replace('.zip', '.root'))
         
             # Add job
             job = Job(name='run-pax.sh')
@@ -167,7 +167,7 @@ class Outsource:
             job.uses(determine_rse, link=Link.INPUT)
             job.uses(json_infile, link=Link.INPUT)
             job.uses(paxify, link=Link.INPUT)
-            #job.uses(job_output, link=Link.OUTPUT)
+            job.uses(job_output, link=Link.OUTPUT)
             dax.addJob(job)
         
         # Write the DAX to stdout

--- a/outsource/RunConfig.py
+++ b/outsource/RunConfig.py
@@ -1,0 +1,127 @@
+import os
+import re
+import time
+from outsource.Config import Config
+from outsource import db
+
+config = Config()
+
+
+class RunConfigBase:
+    """Base class that sets the defaults"""
+
+    _update_run_db = False
+    _force_rerun = False
+    _x509_proxy = os.path.join(os.environ['HOME'], 'user_cert')
+    _executable = os.path.join(config.base_dir(), 'workflow', 'run-pax.sh')
+    _workdir = config.get('Outsource', 'work_dir')
+    _workflow_id = re.sub('\..*', '', str(time.time()))
+    _pax_version = config.get('Outsource', 'pax_version')
+
+
+class RunConfig(RunConfigBase):
+    """Object that gets passed to outsource for each run/workflow.
+
+    This base class has essentially the same info as a dictionary passed as input"""
+
+    required_attributes = ['input_location', 'output_location']
+
+    def __init__(self, **kwargs):
+        for key, val in kwargs.items():
+            setattr(self, "_" + key, val)
+
+        throw_error = False
+        for key in self.required_attributes:
+            if not hasattr(self, "_" + key):
+                print("{name} is required in the input dictionary".format(name=key))
+                throw_error = True
+        if throw_error:
+            raise AttributeError()
+
+    @property
+    def workflow_id(self):
+        return self._workflow_id
+
+    @property
+    def input_location(self):
+        return self._input_location
+
+    @property
+    def output_location(self):
+        return self._output_location
+
+    @property
+    def pax_version(self):
+        return self._pax_version
+
+    @property
+    def update_run_db(self):
+        return self._update_run_db
+
+    @property
+    def force_rerun(self):
+        return self._force_rerun
+
+    @property
+    def x509_proxy(self):
+        return self._x509_proxy
+
+    @property
+    def executable(self):
+        return self._executable
+
+    @property
+    def workdir(self):
+        return self._workdir
+
+    @property
+    def generated_dir(self):
+        return os.path.join(self.workdir, 'generated', self.workflow_id)
+
+    @property
+    def workflow_path(self):
+        return os.path.join(config.runs_dir(), self.workflow_id)
+
+
+class DBConfig(RunConfig):
+    """Uses runDB to build config info"""
+    # default detector is tpc
+    _detector = 'tpc'
+
+    def __init__(self, number, **kwargs):
+        self._number = number
+        self._name = db.get_name(number)
+        self._run_doc = db.get_doc(self.number)
+
+        # eventually get the input location, etc here using DB
+        rawdir = os.path.join('/xenon/xenon1t/raw', self.name)
+        output = os.path.join('/xenon/nt_tests/processed', self.name)
+
+        super().__init__(input_location=rawdir, output_location=output, **kwargs)
+
+
+    @property
+    def workflow_id(self):
+        if self.detector == 'tpc':
+            idstring = "{:06d}".format(self.number)
+        elif self.detector == 'muon_veto':
+            idstring = self.name
+        else:
+            raise NotImplementedError
+        return "xe1t_{detector}_{id}".format(detector=self.detector, id=idstring)
+
+    @property
+    def detector(self):
+        return self._detector
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def number(self):
+        return self._number
+
+    @property
+    def run_doc(self):
+        return self._run_doc

--- a/outsource/RunConfig.py
+++ b/outsource/RunConfig.py
@@ -95,7 +95,7 @@ class DBConfig(RunConfig):
 
         # eventually get the input location, etc here using DB
         rawdir = os.path.join('/xenon/xenon1t/raw', self.name)
-        output = os.path.join('/xenon/nt_tests/processed', self.name)
+        output = os.path.join('/xenon/xenonnt_test/processed', self.name)
 
         super().__init__(input_location=rawdir, output_location=output, **kwargs)
 

--- a/outsource/workflow/paxify.py
+++ b/outsource/workflow/paxify.py
@@ -1,0 +1,63 @@
+"""Replacement for cax-process"""
+import argparse
+import json
+import os
+from pax import core, configuration
+
+
+def process(inputfile, outputdir, json_path):
+    with open(json_path, "r") as f:
+        doc = json.load(f)
+
+    detector = doc['detector']
+    name = doc['name']
+
+    if detector == 'muon_veto':
+        output_fullname = outputdir + '/' + name + '_MV'
+        pax_config = 'XENON1T_MV'
+        decoder = 'BSON.DecodeZBSON'
+
+    elif detector == 'tpc':
+        output_fullname = outputdir + '/' + name
+        decoder = 'Pickle.DecodeZPickle'
+
+        if doc['reader']['self_trigger']:
+            pax_config = 'XENON1T'
+        else:
+            pax_config = 'XENON1T_LED'
+    else:
+        raise ValueError('Detector must be tpc or muon_veto')
+
+    os.makedirs(outputdir, exist_ok=True)
+
+    config_dict = {'pax': {'input_name': inputfile,
+                           'output_name': output_fullname,
+                           'look_for_config_in_runs_db': False,
+                           'decoder_plugin': decoder
+                           }}
+    if detector == 'tpc':
+        mongo_config = doc['processor']
+        config_dict = configuration.combine_configs(mongo_config, config_dict)
+
+    # Add run number and run name to the config_dict
+    config_dict.setdefault('DEFAULT', {})
+    config_dict['DEFAULT']['run_number'] = doc['number']
+    config_dict['DEFAULT']['run_name'] = doc['name']
+
+    pax_kwargs = dict(config_names=pax_config,
+                      config_dict=config_dict)
+
+    core.Processor(**pax_kwargs).run()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Process with pax given a json file')
+    parser.add_argument("--input", type=str, help='Input file')
+    parser.add_argument("--output", type='str', help='Directory to save output')
+    parser.add_argument("--json_path", type=str, help='path to json file')
+    args = parser.parse_args()
+    process(args.input, args.output, args.json_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/outsource/workflow/paxify.py
+++ b/outsource/workflow/paxify.py
@@ -13,12 +13,12 @@ def process(inputfile, outputdir, json_path):
     name = doc['name']
 
     if detector == 'muon_veto':
-        output_fullname = outputdir + '/' + name + '_MV'
+        output_fullname = os.path.join(outputdir, name + '_MV')
         pax_config = 'XENON1T_MV'
         decoder = 'BSON.DecodeZBSON'
 
     elif detector == 'tpc':
-        output_fullname = outputdir + '/' + name
+        output_fullname = os.path.join(outputdir, name)
         decoder = 'Pickle.DecodeZPickle'
 
         if doc['reader']['self_trigger']:
@@ -53,7 +53,7 @@ def process(inputfile, outputdir, json_path):
 def main():
     parser = argparse.ArgumentParser(description='Process with pax given a json file')
     parser.add_argument("--input", type=str, help='Input file')
-    parser.add_argument("--output", type='str', help='Directory to save output')
+    parser.add_argument("--output", type=str, help='Directory to save output')
     parser.add_argument("--json_path", type=str, help='path to json file')
     args = parser.parse_args()
     process(args.input, args.output, args.json_path)

--- a/outsource/workflow/paxify.py
+++ b/outsource/workflow/paxify.py
@@ -33,7 +33,8 @@ def process(inputfile, outputdir, json_path):
     config_dict = {'pax': {'input_name': inputfile,
                            'output_name': output_fullname,
                            'look_for_config_in_runs_db': False,
-                           'decoder_plugin': decoder
+                           'decoder_plugin': decoder,
+                           'stop_after': 10 # temporary
                            }}
     if detector == 'tpc':
         mongo_config = doc['processor']

--- a/outsource/workflow/run-pax.sh
+++ b/outsource/workflow/run-pax.sh
@@ -169,7 +169,7 @@ echo 'Processing...'
 #echo "cax-process $1 $rawdata_path $3 $4 output $7 $8 $start_dir/${json_file}"
 #cax-process $1 $rawdata_path $3 $4 output $7 $8 ${start_dir}/${json_file}
 
-python paxify.py --input ${rawdata_path} --output ./ --json_path run_info.json
+python paxify.py --input ${rawdata_path} --output output --json_path run_info.json
 
 if [[ $? -ne 0 ]];
 then 

--- a/outsource/workflow/run-pax.sh
+++ b/outsource/workflow/run-pax.sh
@@ -150,7 +150,7 @@ old_pythonpath=$PYTHONPATH
 unset PYTHONPATH
 
 export LD_LIBRARY_PATH=$anaconda_env/lib:$LD_LIBRARY_PATH
-source $anaconda_env/activate pax_${pax_version} #_OSG
+source $anaconda_env/activate pax_v${pax_version} #_OSG
 echo $PYTHONPATH
 
 export LD_LIBRARY_PATH=/cvmfs/xenon.opensciencegrid.org/releases/anaconda/2.4/envs/pax_${pax_version}_OSG/lib:$LD_LIBRARY_PATH

--- a/outsource/workflow/run-pax.sh
+++ b/outsource/workflow/run-pax.sh
@@ -5,11 +5,8 @@ export run_id=$1
 export zip_file=$2
 export rucio_dataset=$3
 export stash_gridftp_url=$4
-export submit_host=$5
-export pax_version=$6
-export pax_hash=$7
-export core_count=$8
-export send_updates=$9
+export pax_version=$5
+export send_updates=$6
 
 start_dir=$PWD
 
@@ -91,7 +88,7 @@ curl_moni () {
 echo "start dir is $start_dir. Here's whats inside"
 ls -l 
 
-json_file=$(ls *json)
+#json_file=$(ls *json)
 
 # Pegasus has started the job in a work dir
 work_dir=$PWD
@@ -167,12 +164,12 @@ echo
 echo
 echo 'Processing...'
 
-stash_loc=$6
-
 (curl_moni "start processing") || (curl_moni "start processing")
 
-echo "cax-process $1 $rawdata_path $3 $4 output $7 $8 $start_dir/${json_file}" 
-cax-process $1 $rawdata_path $3 $4 output $7 $8 ${start_dir}/${json_file}
+#echo "cax-process $1 $rawdata_path $3 $4 output $7 $8 $start_dir/${json_file}"
+#cax-process $1 $rawdata_path $3 $4 output $7 $8 ${start_dir}/${json_file}
+
+python paxify.py --input ${rawdata_path} --output output --json_path run_info.json
 
 if [[ $? -ne 0 ]];
 then 

--- a/outsource/workflow/run-pax.sh
+++ b/outsource/workflow/run-pax.sh
@@ -169,7 +169,7 @@ echo 'Processing...'
 #echo "cax-process $1 $rawdata_path $3 $4 output $7 $8 $start_dir/${json_file}"
 #cax-process $1 $rawdata_path $3 $4 output $7 $8 ${start_dir}/${json_file}
 
-python paxify.py --input ${rawdata_path} --output output --json_path run_info.json
+python paxify.py --input ${rawdata_path} --output ./ --json_path run_info.json
 
 if [[ $? -ne 0 ]];
 then 
@@ -187,9 +187,6 @@ source deactivate
 (curl_moni "end processing") || (curl_moni "end processing")
 
 echo "---- Test line ----"
-echo "Processing done, here's what's inside the output directory:"
-outfile=$(ls ${start_dir}/output/)
-echo "-----"
-ls ${start_dir}/output/*.root
+ls ${start_dir}/*.root
 echo "-----"
 

--- a/tests/submit-test-workflow.py
+++ b/tests/submit-test-workflow.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 from outsource.Outsource import Outsource
-from outsource.Config import Config, ConfigDB
+from outsource.RunConfig import DBConfig
 
 if __name__ == '__main__':
-    config = ConfigDB(49)
-    #outsource = Outsource(config)
-    outsource = Outsource(detector = 'tpc', name = '160809_1454', force_rerun = True, update_run_db = False)
+    config = DBConfig(2023)
+    outsource = Outsource(config)
     outsource.submit_workflow()


### PR DESCRIPTION
This replaces cax-process with paxify.py which is copied to the worker in similar way to determine_rse (for the moment at least - can change later). It also adds the RunConfig class which is passed as input to Outsource. 

It's not quite working fully, but I think it's close. 