### PR TITLE
Generalize processing layers and add straxen version information

### DIFF
--- a/outsource/workflow/combine-wrapper.sh
+++ b/outsource/workflow/combine-wrapper.sh
@@ -16,9 +16,7 @@ for TAR in `ls *.tar.gz`; do
     tar xzf $TAR
 done
 
-ls -la
-
-echo "---- data dir ----"
+echo "data dir:"
 ls -l data
 
 echo
@@ -27,14 +25,20 @@ echo
 echo
 echo
 
-# source the environment
-. /opt/XENONnT/setup.sh
-
 export XENON_CONFIG=$PWD/.xenon_config
 export RUCIO_ACCOUNT=production
 
+# source the environment
+. /opt/XENONnT/setup.sh
+
+echo
+echo
+rucio whoami
+echo
+echo
+
 # combine the data
-./combine.py ${runid} ${dtype} --input_path data --output_path combined --context ${context}
+./combine.py ${runid} ${dtype} --input data --context ${context}
 # upload to rucio and update runDB
 ./upload.py ${runid} ${dtype} ${rse} --context ${context}
 

--- a/outsource/workflow/combine.py
+++ b/outsource/workflow/combine.py
@@ -1,60 +1,46 @@
 #!/usr/bin/env python
 
 import argparse
-import tempfile
 import os
-from shutil import copytree, rmtree
 import strax
 import straxen
-from utilix import db
-from admix.interfaces.rucio_summoner import RucioSummoner
-from admix.utils.naming import make_did
-
 
 def main():
     parser = argparse.ArgumentParser(description="Combine strax output")
     parser.add_argument('dataset', help='Run number', type=int)
     parser.add_argument('dtype', help='dtype to combine')
     parser.add_argument('--context', help='Strax context')
-    parser.add_argument('--input_path', help='path where the temp directory is')
-    parser.add_argument('--output_path', help='final location of combined data')
+    parser.add_argument('--input', help='path where the temp directory is')
 
     args = parser.parse_args()
 
-    if os.path.exists(args.output_path):
-        raise(FileExistsError("Output path %s already exists" % args.output_path))
+    #if os.path.exists(args.output_path):
+    #    raise(FileExistsError("Output path %s already exists" % args.output_path))
 
     runid = args.dataset
     runid_str = "%06d" % runid
     dtype = args.dtype
-    path = args.input_path
-    output_path = args.output_path
+    path = args.input
 
     # get context
     st = eval(f'straxen.contexts.{args.context}()')
-    st.storage = [strax.DataDirectory(output_path)]
+    st.storage = [strax.DataDirectory('./')]
 
     # initialize plugin needed for processing
     plugin = st._get_plugins((dtype,), runid_str)[dtype]
     st._set_plugin_config(plugin, runid_str, tolerant=False)
     plugin.setup()
 
-    # setup rucio client
-    rc = RucioSummoner()
-
-
     for keystring in plugin.provides:
-        dirname = f"{runid_str}-{keystring}-{hash}"
-        upload_path = os.path.join(output_path, dirname)
-
         key = strax.DataKey(runid_str, keystring, plugin.lineage)
         saver = st.storage[0].saver(key, plugin.metadata(runid_str, keystring))
+        # monkey patch the saver
+        tmpname = os.path.split(saver.tempdirname)[1]
+        dirname = os.path.split(saver.dirname)[1]
+        saver.tempdirname = os.path.join(path, tmpname)
+        saver.dirname = os.path.join(path, dirname)
         saver.is_forked = True
 
-        tmpdir, tmpname = os.path.split(saver.tempdirname)
-        rmtree(saver.tempdirname)
-        copytree(os.path.join(path, tmpname), saver.tempdirname)
-        saver.is_forked = True
         saver.close()
 
 

--- a/outsource/workflow/pegasus.conf
+++ b/outsource/workflow/pegasus.conf
@@ -8,7 +8,7 @@ pegasus.data.configuration = nonsharedfs
 #pegasus.gridstart.arguments = -f
 
 # give jobs a total of 1+{retry} tries
-dagman.retry = 3
+dagman.retry = 2
 
 dagman.maxidle = 5000
 

--- a/tests/submit-single-test-workflow.py
+++ b/tests/submit-single-test-workflow.py
@@ -10,12 +10,12 @@ from outsource.RunConfig import DBConfig
 
 def main():
     parser = argparse.ArgumentParser("Outsource Testing")
-    parser.add_argument('--run', type=int, default=7695)
+    parser.add_argument('--run', type=int, default=7694)
     parser.add_argument('--context', default='xenonnt_online')
 
     args = parser.parse_args()
 
-    configs = [DBConfig(args.run, strax_context=args.context)]
+    configs = [DBConfig(args.run, strax_context=args.context, straxen_version='0.11.0')]
     outsource = Outsource(configs)
     outsource.submit_workflow()
 


### PR DESCRIPTION
This is somewhat large PR that includes generalizations and streamlining of the workflow in a few places.

- Outsource now would look in the utilix config for what data it should try to process. The main arguments given are then a context name and straxen version, which outsource uses to determine what data needs to be processed. 

-  Code is cleaned up so that we don't have to do copy + paste for the different processing levels. 

- The combine job is optimized a bit so that we don't have to move/copy data around during the job, like we did before. 

I'm sure there are others, but those are the main things off the top of my head. Nearly every file changed in some way. 