### PR TITLE
Raw_records and records on same job

### DIFF
--- a/outsource/workflow/pegasus.conf
+++ b/outsource/workflow/pegasus.conf
@@ -7,6 +7,8 @@ pegasus.data.configuration = nonsharedfs
 # successful jobs
 #pegasus.gridstart.arguments = -f
 
+# pegasus.mode = development
+
 # give jobs a total of 1+{retry} tries
 dagman.retry = 2
 
@@ -14,7 +16,7 @@ dagman.retry = 2
 dagman.maxidle = 50
 
 # total number of jobs cap
-dagman.maxjobs = 500
+dagman.maxjobs = 300
 
 # transfer parallelism
 pegasus.transfer.threads = 8

--- a/outsource/workflow/pre-flight-wrapper.sh
+++ b/outsource/workflow/pre-flight-wrapper.sh
@@ -10,9 +10,20 @@ export DTYPE=$2
 export CONTEXT=$3
 export RSE=$4
 export CMT=$5
-export UPDATE_DB=$6
+export update_db=$6
+export upload_to_rucio=$7
 
 set -e
+
+combine_extra_args=""
+
+if [ "X$update_db" = "Xtrue" ]; then
+    combine_extra_args="$combine_extra_args --update-db"
+fi
+if [ "X$upload_to_rucio" = "Xtrue" ]; then
+    combine_extra_args="$combine_extra_args --upload-to-rucio"
+fi
+
 
 # source the environment
 . /opt/XENONnT/setup.sh
@@ -20,9 +31,7 @@ export XENON_CONFIG=$PWD/.xenon_config
 export RUCIO_ACCOUNT=production
 
 # sleep a random amount of time to spread out e.g. API calls
-sleep $[ ( $RANDOM % 20 )  + 1 ]s
+sleep $[ ( $RANDOM % 100 )  + 1 ]s
 
-if [ "X$UPDATE_DB" = "Xtrue" ]; then
-    ./pre-flight.py $RUNID --dtype $DTYPE --context $CONTEXT --rse $RSE --cmt $CMT
-fi
+./pre-flight.py $RUNID --dtype $DTYPE --context $CONTEXT --rse $RSE --cmt $CMT ${combine_extra_args}
 

--- a/outsource/workflow/pre-flight.py
+++ b/outsource/workflow/pre-flight.py
@@ -33,12 +33,18 @@ def main():
     parser.add_argument('--context', help='Context name', required=True)
     parser.add_argument('--rse', help='RSE to create replication rule at')
     parser.add_argument('--cmt', help='Global CMT version', default='ONLINE')
+    parser.add_argument('--update-db', help='flag to update runsDB', dest='update_db',
+                        action='store_true')
+    parser.add_argument('--upload-to-rucio', help='flag to upload to rucio', dest='upload_to_rucio',
+                        action='store_true')
 
     args = parser.parse_args()
 
     runid = args.runid
     runid_str = "%06d" % runid
     dtype = args.dtype
+
+    dtypes = ['records', 'peaklets']
 
     # setup rucio client
     C = Client()
@@ -49,60 +55,72 @@ def main():
     # apply global version
     apply_global_version(st, args.cmt)
 
-    # initialize plugin needed for processing this output type
-    plugin = st._get_plugins((dtype,), runid_str)[dtype]
+    for dtype in dtypes:
 
-    st._set_plugin_config(plugin, runid_str, tolerant=False)
-    plugin.setup()
+        # initialize plugin needed for processing this output type
+        plugin = st._get_plugins((dtype,), runid_str)[dtype]
 
-    for _dtype in plugin.provides:
-        hash = get_hashes(st)[_dtype]
+        st._set_plugin_config(plugin, runid_str, tolerant=False)
+        plugin.setup()
 
-        # need to create the dataset we will be uploading data to out on the grid
-        dataset = make_did(args.runid, _dtype, hash)
-        scope, name = dataset.split(':')
+        for _dtype in plugin.provides:
+            hash = get_hashes(st)[_dtype]
 
-        # check if this dataset exists
-        existing_datasets = [i for i in C.list_dids(scope, filters=dict(type='dataset'))]
+            # need to create the dataset we will be uploading data to out on the grid
+            dataset = make_did(args.runid, _dtype, hash)
+            scope, name = dataset.split(':')
 
-        if name not in existing_datasets:
-            C.add_dataset(scope, name)
-            print(f"Dataset {dataset} created")
-        else:
-            print(f"Warning: The dataset {dataset} already exists!")
-            #raise ValueError(f"The dataset {dataset} already exists!")
+            # check if this dataset exists
+            existing_datasets = [i for i in C.list_dids(scope, filters=dict(type='dataset'))]
 
-        #check if a rule already exists
-        existing_rules = [i['rse_expression'] for i in C.list_did_rules(scope, name)]
+            if name not in existing_datasets:
+                C.add_dataset(scope, name)
+                print(f"Dataset {dataset} created")
+            else:
+                print(f"Warning: The dataset {dataset} already exists!")
+                #raise ValueError(f"The dataset {dataset} already exists!")
 
-        if args.rse not in existing_rules:
-            # 1 is the number of copies
+            #check if a rule already exists
+            existing_rules = [i['rse_expression'] for i in C.list_did_rules(scope, name)]
 
-            C.add_replication_rule([dict(scope=scope, name=name)], 1, args.rse)
-            print(f"Replication rule at {args.rse} created")
+            # update runDB
+            new_data_dict = dict()
+            new_data_dict['location'] = args.rse
+            new_data_dict['did'] = dataset
+            new_data_dict['status'] = 'processing'
+            new_data_dict['host'] = "rucio-catalogue"
+            new_data_dict['type'] = _dtype
+            new_data_dict['protocol'] = 'rucio'
+            new_data_dict['creation_time'] = datetime.datetime.utcnow().isoformat()
+            new_data_dict['creation_place'] = "OSG"
+            new_data_dict['meta'] = dict(lineage=None,
+                                         avg_chunk_mb=None,
+                                         file_count=None,
+                                         size_mb=None,
+                                         strax_version=strax.__version__,
+                                         straxen_version=straxen.__version__
+                                         )
 
-        # TODO do a step to update the status for this data type?
-        # update runDB
-        new_data_dict = dict()
-        new_data_dict['location'] = args.rse
-        new_data_dict['did'] = dataset
-        new_data_dict['status'] = 'processing'
-        new_data_dict['host'] = "rucio-catalogue"
-        new_data_dict['type'] = _dtype
-        new_data_dict['protocol'] = 'rucio'
-        new_data_dict['creation_time'] = datetime.datetime.utcnow().isoformat()
-        new_data_dict['creation_place'] = "OSG"
-        new_data_dict['meta'] = dict(lineage=None,
-                                     avg_chunk_mb=None,
-                                     file_count=None,
-                                     size_mb=None,
-                                     strax_version=strax.__version__,
-                                     straxen_version=straxen.__version__
-                                     )
+            if args.rse not in existing_rules:
+                # 1 is the number of copies
+                if args.upload_to_rucio:
+                    C.add_replication_rule([dict(scope=scope, name=name)], 1, args.rse)
+                    print(f"Replication rule at {args.rse} created")
 
-        pprint(new_data_dict)
-        #db.update_data(runid, new_data_dict)
+                if args.update_db:
+                    db.update_data(runid, new_data_dict)
+
+                # send peaklets data to dali
+                if dtype == 'peaklets' and args.rse != 'UC_DALI_USERDISK':
+                    if args.upload_to_rucio:
+                        C.add_replication_rule([dict(scope=scope, name=name)], 1, 'UC_DALI_USERDISK',
+                                               source_replica_expression=args.rse,
+                                               priority=5)
+                    # if args.update_db:
+                    #     new_data_dict['location'] = 'UC_DALI_USERDISK'
+                    #     db.update_data(runid, new_data_dict)
 
 
 if __name__ == "__main__":
     main()
+

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(name='outsource',
       long_description=readme(),
       url='https://github.com/XENONnT/outsource',
       packages=['outsource'],
+      entry_points={'console_scripts': ['outsource=outsource.main:main']},
       install_requires=['markdown',
                         'utilix'
                         ],


### PR DESCRIPTION
Here's a reasonably large update. I just tested it on a large amount of data and it worked quite well!

- The main change is it allows you to process peaklets directly from raw_records on the per-chunk jobs. We create records in the process and upload it to rucio. The removes an extra data transfer which is nice, and reduces the number of jobs required for a single workflow substantially. 
- I also added a `outsource` command so that you can easily submit workflows for individual runs or lists of runs. There's definitely more we can do here, but it's a convenient start. 
- Data for high level stuff gets copied to Dali automatically. And there's some runDB changes etc.
- I reduced the max_jobs to 300 because I was seeing rucio problems last night during the large submission. 

