### PR TITLE
Workaround for `cutax v1.15.0`

### DIFF
--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -685,7 +685,7 @@ class Outsource:
         for opt, cmt_info in cmt_options.items():
             for d, plugin in st._plugin_class_registry.items():
                 if opt in plugin.takes_config:
-                    #
+                    # get the correction name and version
                     if isinstance(cmt_info, dict):
                         collname = cmt_info['correction']
                         strax_opt = cmt_info['strax_option']

--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -105,6 +105,11 @@ class Outsource:
         self.context_name = context_name
         self.context = getattr(cutax.contexts, context_name)(cut_list=None)
 
+        # register event_info manually, otherwise in cutax v1.15.0 you will have
+        # cutax.plugins.acsideband.ACSideband for event_info
+        del self.context._plugin_class_registry['event_info']
+        self.context.register(straxen.EventInfo)
+
         # Load from xenon_config
         self.xsede = config.getboolean('Outsource', 'use_xsede', fallback=False)
         self.debug = debug


### PR DESCRIPTION
Trying to bypass tricky feature related to `event_info` described [here](https://github.com/XENONnT/cutax/issues/268). Otherwise you run into this issue:
```
Traceback (most recent call last):
  File "/home/yuanlq/.local/bin/outsource", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/yuanlq/software/outsource/bin/outsource", line 233, in <module>
    main()
  File "/home/yuanlq/software/outsource/bin/outsource", line 229, in main
    outsource.submit_workflow()
  File "/home/yuanlq/software/outsource/outsource/Outsource.py", line 181, in submit_workflow
    wf = self._generate_workflow()
  File "/home/yuanlq/software/outsource/outsource/Outsource.py", line 284, in _generate_workflow
    start_valid, end_valid = self.dtype_validity(dtype)
  File "/home/yuanlq/software/outsource/outsource/Outsource.py", line 699, in dtype_validity
    dependencies = self.get_dependencies(dtype)
  File "/home/yuanlq/software/outsource/outsource/Outsource.py", line 738, in get_dependencies
    _get_dependencies(dtype)
  File "/home/yuanlq/software/outsource/outsource/Outsource.py", line 736, in _get_dependencies
    _get_dependencies(dep)
  File "/home/yuanlq/software/outsource/outsource/Outsource.py", line 730, in _get_dependencies
    depends_on = [x for x in depends_on]
TypeError: 'property' object is not iterable
```