### PR TITLE
Removed cuts from registered plugin

### DIFF
--- a/bin/outsource
+++ b/bin/outsource
@@ -6,6 +6,7 @@ from utilix.io import load_runlist
 from utilix import xent_collection
 from utilix.rundb import cmt_local_valid_range
 import cutax
+import straxen
 
 from outsource.Outsource import Outsource, DEFAULT_IMAGE
 from outsource.Config import config
@@ -178,10 +179,22 @@ def main():
     if args.debug:
         upload_to_rucio = update_db = False
 
+    # register event_info manually, otherwise in cutax v1.15.0 you will have
+    # cutax.plugins.acsideband.ACSideband for event_info
     st = getattr(cutax.contexts, args.context)()
+    del st._plugin_class_registry['event_info']
+    st.register(straxen.EventInfo)
+    
+    # remove cuts if there is any
+    all_plugin_keys_registrerd = list(st._plugin_class_registry.keys())
+    for registered_plugin in all_plugin_keys_registrerd:
+        if ('cut' in registered_plugin) or ('cuts' in registered_plugin):
+            del st._plugin_class_registry[registered_plugin]
+        elif 'cut' in str(st._plugin_class_registry[registered_plugin]):
+            del st._plugin_class_registry[registered_plugin]
 
-    if args.run and args.runlist:
-        raise RuntimeError("Cannot pass both --run and --runlist. Please choose one.")
+        if args.run and args.runlist:
+            raise RuntimeError("Cannot pass both --run and --runlist. Please choose one.")
 
     # subset of runs to consider during data find
     _runlist = None

--- a/bin/outsource
+++ b/bin/outsource
@@ -184,7 +184,6 @@ def main():
     st = getattr(cutax.contexts, args.context)()
     del st._plugin_class_registry['event_info']
     st.register(straxen.EventInfo)
-    
     # remove cuts if there is any
     all_plugin_keys_registrerd = list(st._plugin_class_registry.keys())
     for registered_plugin in all_plugin_keys_registrerd:
@@ -192,6 +191,9 @@ def main():
             del st._plugin_class_registry[registered_plugin]
         elif 'cut' in str(st._plugin_class_registry[registered_plugin]):
             del st._plugin_class_registry[registered_plugin]
+    # remove diffusion_constant if there is one to avoid warning message
+    if "diffusion_constant" in st.config.keys():
+        del st.config["diffusion_constant"]
 
     if args.run and args.runlist:
         raise RuntimeError("Cannot pass both --run and --runlist. Please choose one.")

--- a/bin/outsource
+++ b/bin/outsource
@@ -193,8 +193,8 @@ def main():
         elif 'cut' in str(st._plugin_class_registry[registered_plugin]):
             del st._plugin_class_registry[registered_plugin]
 
-        if args.run and args.runlist:
-            raise RuntimeError("Cannot pass both --run and --runlist. Please choose one.")
+    if args.run and args.runlist:
+        raise RuntimeError("Cannot pass both --run and --runlist. Please choose one.")
 
     # subset of runs to consider during data find
     _runlist = None

--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -110,6 +110,14 @@ class Outsource:
         del self.context._plugin_class_registry['event_info']
         self.context.register(straxen.EventInfo)
 
+        # remove cuts if there is any
+        all_plugin_keys_registrerd = list(self.context._plugin_class_registry.keys())
+        for registered_plugin in all_plugin_keys_registrerd:
+            if ('cut_' in registered_plugin) or ('cuts_' in registered_plugin):
+                del self.context._plugin_class_registry[registered_plugin]
+            elif 'cutax' in str(self.context._plugin_class_registry[registered_plugin]):
+                del self.context._plugin_class_registry[registered_plugin]
+
         # Load from xenon_config
         self.xsede = config.getboolean('Outsource', 'use_xsede', fallback=False)
         self.debug = debug

--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -117,8 +117,8 @@ class Outsource:
             elif 'cutax' in str(self.context._plugin_class_registry[registered_plugin]):
                 del self.context._plugin_class_registry[registered_plugin]
         # remove diffusion_constant if there is one to avoid warning message
-        if "diffusion_constant" in st.config.keys():
-            del st.config["diffusion_constant"]
+        if "diffusion_constant" in selfcontext.config.keys():
+            del self.context.config["diffusion_constant"]
 
         # Load from xenon_config
         self.xsede = config.getboolean('Outsource', 'use_xsede', fallback=False)

--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -109,7 +109,6 @@ class Outsource:
         # cutax.plugins.acsideband.ACSideband for event_info
         del self.context._plugin_class_registry['event_info']
         self.context.register(straxen.EventInfo)
-
         # remove cuts if there is any
         all_plugin_keys_registrerd = list(self.context._plugin_class_registry.keys())
         for registered_plugin in all_plugin_keys_registrerd:
@@ -117,6 +116,9 @@ class Outsource:
                 del self.context._plugin_class_registry[registered_plugin]
             elif 'cutax' in str(self.context._plugin_class_registry[registered_plugin]):
                 del self.context._plugin_class_registry[registered_plugin]
+        # remove diffusion_constant if there is one to avoid warning message
+        if "diffusion_constant" in st.config.keys():
+            del st.config["diffusion_constant"]
 
         # Load from xenon_config
         self.xsede = config.getboolean('Outsource', 'use_xsede', fallback=False)

--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -117,7 +117,7 @@ class Outsource:
             elif 'cutax' in str(self.context._plugin_class_registry[registered_plugin]):
                 del self.context._plugin_class_registry[registered_plugin]
         # remove diffusion_constant if there is one to avoid warning message
-        if "diffusion_constant" in selfcontext.config.keys():
+        if "diffusion_constant" in self.context.config.keys():
             del self.context.config["diffusion_constant"]
 
         # Load from xenon_config


### PR DESCRIPTION
Related to [this issue](https://github.com/XENONnT/cutax/pull/269), but it is always good to make sure our registered plugins in `outsource` is as few as necessary. If we don't remove the cuts, we will have super slow `st.provided_dtypes` and `straxen.get_corrections.get_cmt_options(st)` which leads to 15 min to submit a single job.