### PR TITLE
`chunks_per_job` into config

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ notification_email =
 min_run_number = 
 max_daily = 
 this_site_only = 
+chunks_per_job = 
 hs06_test_run = False
 ```
 

--- a/outsource/RunConfig.py
+++ b/outsource/RunConfig.py
@@ -70,7 +70,7 @@ class RunConfigBase:
     _x509_proxy = os.path.join(os.environ['HOME'], 'user_cert')
     _workdir = work_dir
     _workflow_id = re.sub('\..*', '', str(time.time()))
-    _chunks_per_job = 25
+    _chunks_per_job = config.getint('Outsource', 'chunks_per_job')
 
     @property
     def force_rerun(self):


### PR DESCRIPTION
So now we can test how we can accelerate `peaklets` jobs with smaller RAM!