### PR TITLE
Fixed abuse of `raw_records_rse`

### DIFF
--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -348,10 +348,6 @@ class Outsource:
                 if dbcfg.standalone_download:
                     rses = rses_specified
 
-                # The rse list should be intersection of what we want and what we have
-                rses = list(set(rses_specified) & set(rses))
-                if len(rses) == 0:
-                    raise RuntimeError(f'Unable to find a raw records location for {dbcfg.number} in raw_records_rse %s'%(rses_specified))
                 sites_expression, desired_sites = self._determine_target_sites(rses)
 
                 # hs06_test_run limits the run to a set of compute nodes at UChicago with a known HS06 factor


### PR DESCRIPTION
In #80 there is a bug introduced. After reading again I realize this is not how we can control the source of `raw_records`. The current implementation will actually shoot error for some runs. 

Also, it turns out that any configuration in current `outsource`+`straxen`+`xe-admix` will NOT take raw_records from SDSC_NSDF_USERDISK, because of this this chain [admix](https://github.com/XENONnT/admix/blob/d7ac0d106672b10f47e3a4c45560a2eca214755e/admix/downloader.py#L61)->[straxen](https://github.com/XENONnT/straxen/blob/6bddda5679ecb5cb2c718912242173c24638e989/straxen/storage/rucio_remote.py#L125C36-L125C49)->[outsource](https://github.com/XENONnT/outsource/blob/bb89bb4cc832b618ec75eb3c8e658dc8e27a05da/outsource/workflow/runstrax.py#L261) Unless UC_OSG_USERDISK has no copy of raw_records for the interested run, it will not use SDSC_NSDF_USERDISK as raw_records site at all!