### PR TITLE
Improved usage of `raw_records_rses`

### DIFF
--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -352,6 +352,10 @@ class Outsource:
                 if dbcfg.standalone_download:
                     rses = rses_specified
 
+                # For low level data, we only want to run on sites that have the raw data
+                if dtype in NEED_RAW_DATA_DTYPES:
+                    rses = np.intersect1d(rses, rses_specified)
+
                 sites_expression, desired_sites = self._determine_target_sites(rses)
 
                 # hs06_test_run limits the run to a set of compute nodes at UChicago with a known HS06 factor

--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -352,9 +352,10 @@ class Outsource:
                 if dbcfg.standalone_download:
                     rses = rses_specified
 
-                # For low level data, we only want to run on sites that have the raw data
+                # For low level data, we only want to run on sites that we specified for raw_records_rse
                 if dtype in NEED_RAW_DATA_DTYPES:
                     rses = np.intersect1d(rses, rses_specified)
+                    assert len(rses) > 0, f'No sites found for {dbcfg.number} {dtype}, since no intersection between the available rses {rses} and the specified raw_records_rses {rses_specified}'
 
                 sites_expression, desired_sites = self._determine_target_sites(rses)
 


### PR DESCRIPTION
Still cannot specify from which site admix.download will do for the raw_records. but in the following cases, we are doing better:

1. If have `raw_records` available at both `SOMEWHERE` and `SURFSARA_USERDISK`, and we specified `raw_records_rse = SURFSARA_USERDISK`, the desired sites will be only `SURFSARA_USERDISK `.
2. If have `raw_records` available at both `SDSC_NSDF_USERDISK` and `SURFSARA_USERDISK`, and we specified `raw_records_rse = SDSC_NSDF_USERDISK`, the desired sites will be only `NONE` (because `'SDSC_NSDF_USERDISK': {'expr': 'GLIDEIN_Country == "US"'}` in `_rse_site_map`).