### PR TITLE
Prioritize heavy low level types in runstrax

### DIFF
--- a/outsource/workflow/runstrax.py
+++ b/outsource/workflow/runstrax.py
@@ -18,6 +18,7 @@ import datetime
 import cutax
 import glob
 import json
+import gc
 
 from admix.clients import rucio_client
 
@@ -390,6 +391,7 @@ def main():
                 close_savers=close_savers,
                 tmp_path=_tmp_path
                 )
+        gc.collect()
 
     print("Done processing. Now check if we should upload to rucio")
 

--- a/outsource/workflow/runstrax.py
+++ b/outsource/workflow/runstrax.py
@@ -152,6 +152,10 @@ def process(runid,
     # now move on to processing
     # if we didn't pass any chunks, we process the whole thing -- otherwise just do the chunks we listed
     if chunks is None:
+        if plugin.save_when == strax.SaveWhen.NEVER:
+            print("This plugin is not saving anything. Skipping.")
+            return
+            
         print("Chunks is none -- processing whole thing!")
         # then we just process the whole thing
         for keystring in plugin.provides:
@@ -159,7 +163,7 @@ def process(runid,
             st.make(runid_str, keystring,
                     max_workers=4, #FIXME is it dangerous?
                     allow_multiple=True,
-                    save=keystring,
+                    save=plugin.provides,
                     )
             print(f"DONE processing {keystring}")
 

--- a/outsource/workflow/runstrax.py
+++ b/outsource/workflow/runstrax.py
@@ -43,6 +43,7 @@ ignore_dtypes = ['records',
                  'lone_raw_record_statistics_nv',
                  'records_he',
                  'records_mv',
+                 'peaks',
                  ]
 
 # these dtypes should always be made at the same time:

--- a/outsource/workflow/runstrax.py
+++ b/outsource/workflow/runstrax.py
@@ -159,6 +159,7 @@ def process(runid,
             st.make(runid_str, keystring,
                     max_workers=4, #FIXME is it dangerous?
                     allow_multiple=True,
+                    save=keystring,
                     )
             print(f"DONE processing {keystring}")
 


### PR DESCRIPTION
To save memory, by avoiding staging heavy middle steps in RAM. Save the heavy middle steps first.