### PR TITLE
Added peak_basics into to-check in RunDB

### DIFF
--- a/outsource/RunConfig.py
+++ b/outsource/RunConfig.py
@@ -25,7 +25,7 @@ DEPENDS_ON = {'records': ['raw_records'],
               'led_calibration': ['raw_records']
               }
 
-DETECTOR_DTYPES = {'tpc': ['records', 'peaklets', 'peak_basics', 'event_info_double', 
+DETECTOR_DTYPES = {'tpc': ['records', 'peaklets', 'peak_basics', 'event_info_double', 'event_ambience',
                            'event_shadow', 'peak_basics_he', 'afterpulses', 'led_calibration'],
                    'neutron_veto': ['hitlets_nv', 'events_nv'],
                    'muon_veto': ['events_mv']

--- a/outsource/RunConfig.py
+++ b/outsource/RunConfig.py
@@ -32,7 +32,8 @@ DETECTOR_DTYPES = {'tpc': ['records', 'peaklets', 'peak_basics', 'event_info_dou
                    }
 
 # these are datetypes to look for in runDB
-ACTUALLY_STORED = {'event_info_double': ['event_info', 'distinct_channels', 'event_pattern_fit', 
+ACTUALLY_STORED = {'event_info_double': ['peak_basics', 
+                                         'event_info', 'distinct_channels', 'event_pattern_fit', 
                                          'event_area_per_channel', 'event_n_channel',
                                          'event_top_bottom_params', 'event_ms_naive',
                                          'event_ambience', 'event_shadow', 'peak_s1_positions_cnn'],

--- a/outsource/RunConfig.py
+++ b/outsource/RunConfig.py
@@ -25,7 +25,8 @@ DEPENDS_ON = {'records': ['raw_records'],
               'led_calibration': ['raw_records']
               }
 
-DETECTOR_DTYPES = {'tpc': ['records', 'peaklets', 'peak_basics', 'event_info_double', 'event_ambience',
+# Corresponding to keys in ACTUALLY_STORED
+DETECTOR_DTYPES = {'tpc': ['records', 'peaklets', 'peak_basics', 'event_info_double'
                            'event_shadow', 'peak_basics_he', 'afterpulses', 'led_calibration'],
                    'neutron_veto': ['hitlets_nv', 'events_nv'],
                    'muon_veto': ['events_mv']


### PR DESCRIPTION
Expected behavior: if the run doesn't have `peak_basics`, outsource will process this run. 