### PR TITLE
Revisit check chunk n

### DIFF
--- a/outsource/workflow/combine.py
+++ b/outsource/workflow/combine.py
@@ -92,16 +92,25 @@ def check_chunk_n(directory):
     files = sorted(glob.glob(directory+'*'))
     n_chunks = len(files) - 1
     metadata = json.loads(open(files[-1], 'r').read())
+
     if n_chunks != 0:
-        assert n_chunks == len(metadata['chunks']), "There are %s chunks in storage, but metadata says %s"%(n_chunks, len(metadata['chunks']))
+        n_metadata_chunks = len(metadata['chunks'])
+        assert n_chunks == n_metadata_chunks or n_chunks == n_metadata_chunks-1, "For directory %s, \
+                                               there are %s chunks in storage, \
+                                               but metadata says %s. Chunks in storage must be \
+                                               less than chunks in metadata!"%(
+                                                        directory, n_chunks, n_metadata_chunks)
+        
         compressor = metadata['compressor']
         dtype = eval(metadata['dtype'])
+        
         for i in range(n_chunks):
             chunk = strax.load_file(files[i], compressor=compressor, dtype=dtype)
             if metadata['chunks'][i]['n'] != len(chunk):
                 raise strax.DataCorrupted(
                     f"Chunk {files[i]} of {metadata['run_id']} has {len(chunk)} items, "
                     f"but metadata says {metadata['chunks'][i]['n']}")
+
     else:
         assert len(metadata['chunks']) == 1, "There are %s chunks in storage, but metadata says %s"%(n_chunks, len(metadata['chunks']))
         assert metadata['chunks'][0]['n'] == 0, "Empty chunk has non-zero length in metadata!"

--- a/outsource/workflow/combine.py
+++ b/outsource/workflow/combine.py
@@ -95,6 +95,7 @@ def check_chunk_n(directory):
 
     if n_chunks != 0:
         n_metadata_chunks = len(metadata['chunks'])
+        # check that the number of chunks in storage is less than or equal to the number of chunks in metadata
         assert n_chunks == n_metadata_chunks or n_chunks == n_metadata_chunks-1, "For directory %s, \
                                                there are %s chunks in storage, \
                                                but metadata says %s. Chunks in storage must be \
@@ -104,6 +105,7 @@ def check_chunk_n(directory):
         compressor = metadata['compressor']
         dtype = eval(metadata['dtype'])
         
+        # check that the chunk length is agreed with promise in metadata
         for i in range(n_chunks):
             chunk = strax.load_file(files[i], compressor=compressor, dtype=dtype)
             if metadata['chunks'][i]['n'] != len(chunk):
@@ -111,10 +113,12 @@ def check_chunk_n(directory):
                     f"Chunk {files[i]} of {metadata['run_id']} has {len(chunk)} items, "
                     f"but metadata says {metadata['chunks'][i]['n']}")
 
+        # check that the last chunk is empty
         if n_chunks == n_metadata_chunks-1:
             assert metadata['chunks'][n_chunks]['n'] == 0, "Empty chunk has non-zero length in metadata!"
 
     else:
+        # check that the number of chunks in metadata is 1
         assert len(metadata['chunks']) == 1, "There are %s chunks in storage, but metadata says %s"%(n_chunks, len(metadata['chunks']))
         assert metadata['chunks'][0]['n'] == 0, "Empty chunk has non-zero length in metadata!"
     

--- a/outsource/workflow/combine.py
+++ b/outsource/workflow/combine.py
@@ -39,8 +39,6 @@ def merge(runid_str, # run number padded with 0s
     st._set_plugin_config(plugin, runid_str, tolerant=False)
     plugin.setup()
 
-    # plugin.default_chunk_size_mb = 500 # this is not doing anything
-
     to_merge = [d.split('-')[1] for d in os.listdir(path)]
 
     for keystring in plugin.provides:

--- a/outsource/workflow/combine.py
+++ b/outsource/workflow/combine.py
@@ -111,6 +111,9 @@ def check_chunk_n(directory):
                     f"Chunk {files[i]} of {metadata['run_id']} has {len(chunk)} items, "
                     f"but metadata says {metadata['chunks'][i]['n']}")
 
+        if n_chunks == n_metadata_chunks-1:
+            assert metadata['chunks'][n_chunks]['n'] == 0, "Empty chunk has non-zero length in metadata!"
+
     else:
         assert len(metadata['chunks']) == 1, "There are %s chunks in storage, but metadata says %s"%(n_chunks, len(metadata['chunks']))
         assert metadata['chunks'][0]['n'] == 0, "Empty chunk has non-zero length in metadata!"

--- a/outsource/workflow/runstrax.py
+++ b/outsource/workflow/runstrax.py
@@ -291,6 +291,9 @@ def check_chunk_n(directory):
                 raise strax.DataCorrupted(
                     f"Chunk {files[i]} of {metadata['run_id']} has {len(chunk)} items, "
                     f"but metadata says {metadata['chunks'][i]['n']}")
+        
+        if n_chunks == n_metadata_chunks-1:
+            assert metadata['chunks'][n_chunks]['n'] == 0, "Empty chunk has non-zero length in metadata!"
 
     else:
         assert len(metadata['chunks']) == 1, "There are %s chunks in storage, but metadata says %s"%(n_chunks, len(metadata['chunks']))

--- a/outsource/workflow/runstrax.py
+++ b/outsource/workflow/runstrax.py
@@ -273,22 +273,30 @@ def check_chunk_n(directory):
     files = sorted(glob.glob(directory+'*'))
     n_chunks = len(files) - 1
     metadata = json.loads(open(files[-1], 'r').read())
+
     if n_chunks != 0:
-        assert n_chunks == len(metadata['chunks']), "For directory %s, there are %s chunks in storage, but metadata says %s"%(directory, n_chunks, len(metadata['chunks']))
+        n_metadata_chunks = len(metadata['chunks'])
+        assert n_chunks == n_metadata_chunks or n_chunks == n_metadata_chunks-1, "For directory %s, \
+                                               there are %s chunks in storage, \
+                                               but metadata says %s. Chunks in storage must be \
+                                               less than chunks in metadata!"%(
+                                                        directory, n_chunks, n_metadata_chunks)
+        
         compressor = metadata['compressor']
         dtype = eval(metadata['dtype'])
+        
         for i in range(n_chunks):
             chunk = strax.load_file(files[i], compressor=compressor, dtype=dtype)
             if metadata['chunks'][i]['n'] != len(chunk):
                 raise strax.DataCorrupted(
                     f"Chunk {files[i]} of {metadata['run_id']} has {len(chunk)} items, "
                     f"but metadata says {metadata['chunks'][i]['n']}")
+
     else:
         assert len(metadata['chunks']) == 1, "There are %s chunks in storage, but metadata says %s"%(n_chunks, len(metadata['chunks']))
         assert metadata['chunks'][0]['n'] == 0, "Empty chunk has non-zero length in metadata!"
+
     
-
-
 def main():
     parser = argparse.ArgumentParser(description="Strax Processing With Outsource")
     parser.add_argument('dataset', help='Run number', type=int)

--- a/outsource/workflow/runstrax.py
+++ b/outsource/workflow/runstrax.py
@@ -276,6 +276,7 @@ def check_chunk_n(directory):
 
     if n_chunks != 0:
         n_metadata_chunks = len(metadata['chunks'])
+        # check that the number of chunks in storage is less than or equal to the number of chunks in metadata
         assert n_chunks == n_metadata_chunks or n_chunks == n_metadata_chunks-1, "For directory %s, \
                                                there are %s chunks in storage, \
                                                but metadata says %s. Chunks in storage must be \
@@ -285,20 +286,22 @@ def check_chunk_n(directory):
         compressor = metadata['compressor']
         dtype = eval(metadata['dtype'])
         
+        # check that the chunk length is agreed with promise in metadata
         for i in range(n_chunks):
             chunk = strax.load_file(files[i], compressor=compressor, dtype=dtype)
             if metadata['chunks'][i]['n'] != len(chunk):
                 raise strax.DataCorrupted(
                     f"Chunk {files[i]} of {metadata['run_id']} has {len(chunk)} items, "
                     f"but metadata says {metadata['chunks'][i]['n']}")
-        
+
+        # check that the last chunk is empty
         if n_chunks == n_metadata_chunks-1:
             assert metadata['chunks'][n_chunks]['n'] == 0, "Empty chunk has non-zero length in metadata!"
 
     else:
+        # check that the number of chunks in metadata is 1
         assert len(metadata['chunks']) == 1, "There are %s chunks in storage, but metadata says %s"%(n_chunks, len(metadata['chunks']))
         assert metadata['chunks'][0]['n'] == 0, "Empty chunk has non-zero length in metadata!"
-
     
 def main():
     parser = argparse.ArgumentParser(description="Strax Processing With Outsource")

--- a/outsource/workflow/runstrax.py
+++ b/outsource/workflow/runstrax.py
@@ -150,7 +150,6 @@ def process(runid,
     plugin = st._get_plugins((out_dtype,), runid_str)[out_dtype]
     st._set_plugin_config(plugin, runid_str, tolerant=False)
     plugin.setup()
-    plugin.chunk_target_size_mb = 500 #FIXME is it dangerous?
 
     # now move on to processing
     # if we didn't pass any chunks, we process the whole thing -- otherwise just do the chunks we listed


### PR DESCRIPTION
- Deleted recheck size which is misleading and not even used.
- Allow metadata to have one more chunk than in storage, if it is the last chunk and it is empty.

Hopefully we can solve issues like this:
```
        Traceback (most recent call last):
          File "/srv/pegasus.39eVZTyjU/./runstrax.py", line 586, in <module>
            main()
          File "/srv/pegasus.39eVZTyjU/./runstrax.py", line 531, in main
            check_chunk_n(path)
          File "/srv/pegasus.39eVZTyjU/./runstrax.py", line 278, in check_chunk_n
            assert n_chunks == len(metadata['chunks']), "For directory %s, there are %s chunks in storage, but metadata says %s"%(directory, n_chunks, len(metadata['chunks']))
        AssertionError: For directory ./data/051948-merged_s2s-wpzg6lsm2m/, there are 26 chunks in storage, but metadata says 27
```