### PR TITLE
No records or records_nv to upload in rucio

### DIFF
--- a/outsource/workflow/combine.py
+++ b/outsource/workflow/combine.py
@@ -185,6 +185,7 @@ def main():
 
         # We don't want to upload records to rucio
         if keystring == 'records' or keystring == 'records_nv':
+            print("We don't want to upload %s to rucio. Skipping."%(keystring))
             continue
 
         dataset_did = admix.utils.make_did(runid, keystring, straxhash)

--- a/outsource/workflow/combine.py
+++ b/outsource/workflow/combine.py
@@ -182,6 +182,11 @@ def main():
     for this_dir in os.listdir(final_path):
         # prepare list of dicts to be uploaded
         _run, keystring, straxhash = this_dir.split('-')
+
+        # We don't want to upload records to rucio
+        if keystring == 'records':
+            continue
+
         dataset_did = admix.utils.make_did(runid, keystring, straxhash)
         scope, dset_name = dataset_did.split(':')
 

--- a/outsource/workflow/combine.py
+++ b/outsource/workflow/combine.py
@@ -184,7 +184,7 @@ def main():
         _run, keystring, straxhash = this_dir.split('-')
 
         # We don't want to upload records to rucio
-        if keystring == 'records':
+        if keystring == 'records' or keystring == 'records_nv':
             continue
 
         dataset_did = admix.utils.make_did(runid, keystring, straxhash)

--- a/outsource/workflow/strax-wrapper.sh
+++ b/outsource/workflow/strax-wrapper.sh
@@ -110,6 +110,8 @@ fi
 
 echo "Here is what is in the data directory after processing:"
 ls -lah data/*
+echo "We want to find and delete any records or records_nv if existing, to save disk in combine jobs."
+find data -type d \( -name "*-records-*" -o -name "*-records_nv-*" \) -exec rm -rf {} +
 
 
 if [ -z "${chunks}" ]


### PR DESCRIPTION
So we don't saturate disks with unnecessary data types.

- Delete `records` in `strax-wrapper` after processing `peaklets` jobs
- Force not uploading `records` to rucio