### PR TITLE
Save `events` and changing order

### DIFF
--- a/outsource/workflow/combine.py
+++ b/outsource/workflow/combine.py
@@ -5,6 +5,8 @@ import shutil
 import numpy as np
 import strax
 import straxen
+straxen.Events.save_when = strax.SaveWhen.TARGET
+print("We have forced events to save always.")
 import datetime
 import time
 import admix

--- a/outsource/workflow/runstrax.py
+++ b/outsource/workflow/runstrax.py
@@ -412,7 +412,12 @@ def main():
 
     # If to-process has anything in priority_rank, we process them first
     if len(set(priority_rank) & set(to_process)) > 0:
+        # remove any prioritized dtypes that are not in to_process
+        priority_rank = [dtype for dtype in priority_rank if dtype in to_process]
+        # remove the priority_rank dtypes from to_process, as low priority datatypes which we don't
+        # rigorously care their order
         to_process_low_priority = [dt for dt in to_process if dt not in priority_rank]
+        # sort the priority by their dependencies
         to_process = priority_rank + to_process_low_priority
 
     print(f"To process: {', '.join(to_process)}")

--- a/outsource/workflow/runstrax.py
+++ b/outsource/workflow/runstrax.py
@@ -413,12 +413,12 @@ def main():
     # If to-process has anything in priority_rank, we process them first
     if len(set(priority_rank) & set(to_process)) > 0:
         # remove any prioritized dtypes that are not in to_process
-        priority_rank = [dtype for dtype in priority_rank if dtype in to_process]
+        filtered_priority_rank = [dtype for dtype in priority_rank if dtype in to_process]
         # remove the priority_rank dtypes from to_process, as low priority datatypes which we don't
         # rigorously care their order
-        to_process_low_priority = [dt for dt in to_process if dt not in priority_rank]
+        to_process_low_priority = [dt for dt in to_process if dt not in filtered_priority_rank]
         # sort the priority by their dependencies
-        to_process = priority_rank + to_process_low_priority
+        to_process = filtered_priority_rank + to_process_low_priority
 
     print(f"To process: {', '.join(to_process)}")
     _tmp_path = tempfile.mkdtemp()

--- a/outsource/workflow/runstrax.py
+++ b/outsource/workflow/runstrax.py
@@ -7,6 +7,8 @@ import tempfile
 import numpy as np
 import strax
 import straxen
+straxen.Events.save_when = strax.SaveWhen.TARGET
+print("We have forced events to save always.")
 import time
 from pprint import pprint
 from shutil import rmtree, copyfile
@@ -172,7 +174,7 @@ def process(runid,
                             save=keystring,
                             )
                 except:
-                    print(f"Failed to make {keystring}. Skipping")
+                    print(f"Failed to make {keystring}, but it might be due to that the cuts are not ready yet. Skipping")
             else:
                 st.make(runid_str, keystring,
                             save=keystring,

--- a/outsource/workflow/runstrax.py
+++ b/outsource/workflow/runstrax.py
@@ -56,7 +56,9 @@ buddy_dtypes = [('veto_regions_nv', 'event_positions_nv'),
                 ]
 
 # These are the dtypes we want to make first if any of them is in to-process list
-priority_rank = ['peaklet_classification', 'merged_s2s', 'peaks', 'peak_basics']
+priority_rank = ['peaklet_classification', 'merged_s2s', 'peaks', 'peak_basics',
+                 'peak_positions_mlp', 'peak_positions_gcn', 'peak_positions_cnn',
+                 'peak_positions', 'peak_proximity', 'events', 'event_basics' ]
 
 def get_bottom_dtypes(dtype):
     """


### PR DESCRIPTION
Before this PR, a typical TPC workflow's event job will process in the following order

```
peaklet_classification, merged_s2s, peaks, peak_basics, peak_positions_gcn, peak_positions_mlp, peak_positions_cnn, peak_proximity, peak_positions, events, energy_estimates, corrected_areas, event_positions, event_basics, distinct_channels, event_info, event_ambience, event_area_per_channel, event_ms_naive, event_top_bottom_params, peak_s1_positions_cnn, event_pattern_fit, event_info_double, event_shadow, cuts_basic
```

There are two issues:
1. `events` is never computed directly as a target, because of the `save_when == NEVER` nature. @dachengx has pointed out that without saving `events` we might be vulnerable to [chunk merging problem](https://xenonnt.slack.com/archives/C016DM0JPK9/p1706225634628069), as is reported here which we still don't fully understood the mechanism yet.
2. `event_basics`is NOT followed right after `events`. Not sure why this could happen, but not super important.

So in this PR:
1. `events` will be saved, by overwriting `straxen.Events.save_when = strax.SaveWhen.TARGET` right after importing `straxen `and before defining context.
2. Redefined priority rank like below so that `event_basics` will be the first datatype to compute after `events`
```python
priority_rank = ['peaklet_classification', 'merged_s2s', 'peaks', 'peak_basics',
                 'peak_positions_mlp', 'peak_positions_gcn', 'peak_positions_cnn',
                 'peak_positions', 'peak_proximity', 'events', 'event_basics' ]
```
