### PR TITLE
Preupload to avoid rucio orphan files

### DIFF
--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -523,7 +523,7 @@ class Outsource:
                                  )
 
                     job.add_inputs(straxify, xenon_config, token, cutax_tarball)
-                    job.add_outputs(job_output_tar, stage_out=(not self.upload_to_rucio))
+                    job.add_outputs(job_output_tar, stage_out=True) # as long as we are giving outputs
                     wf.add_jobs(job)
 
                     # if there are multiple levels to the workflow, need to have current strax-wrapper depend on

--- a/outsource/workflow/combine.py
+++ b/outsource/workflow/combine.py
@@ -224,6 +224,13 @@ def main():
         print(f"Trying to upload {this_path} to {rse}")
 
         if len(contents_to_upload):
+            print(f"Pre-uploading {path} to rucio!")
+            t0 = time.time()
+            admix.preupload(path, rse=rse, did=dataset_did)
+            preupload_time = time.time() - t0
+            print(f"=== Preuploading time for {keystring}: {preupload_time/60:0.2f} minutes === ")
+            print("--------------------------")
+
             print("Here are the contents to upload:")
             print(contents_to_upload)
             t0 = time.time()

--- a/outsource/workflow/runstrax.py
+++ b/outsource/workflow/runstrax.py
@@ -558,6 +558,13 @@ def main():
         succeded_rucio_upload = False
         try:
             print("--------------------------")
+            print(f"Pre-uploading {path} to rucio!")
+            t0 = time.time()
+            admix.preupload(path, rse=rse, did=dataset_did)
+            preupload_time = time.time() - t0
+            print(f"=== Preuploading time for {this_dtype}: {preupload_time/60:0.2f} minutes === ")
+
+            print("--------------------------")
             print(f"Uploading {path} to rucio!")
             t0 = time.time()
             admix.upload(path, rse=rse, did=dataset_did)


### PR DESCRIPTION
First success to solve #131 and #126:
```
/scratch/yuanlq/workflows/runs/straxen_v2.2.0/xenonnt_offline/sr1_th232_events_test_4/
```
See here for details of an example, where `'veto_regions-hwcemk7dbt-metadata.json'` was an orphan file.
```
        --------------------------
        Checking if chunk length is agreed with promise in metadata for 051432-veto_regions-hwcemk7dbt
        The chunk length is agreed with promise in metadata.
        --------------------------
        Trying to upload finished_data/051432-veto_regions-hwcemk7dbt to UC_MIDWAY_USERDISK
        Pre-uploading data to rucio!
        File 051432-veto_regions-hwcemk7dbt could not be attached
        File 051432-pulse_counts-hwcemk7dbt could not be attached
        File 051432-peaklets-euocvpkv3y could not be attached
        File 051432-lone_hits-euocvpkv3y could not be attached
        === Preuploading time for veto_regions: 0.25 minutes ===
        --------------------------
        Here are the contents to upload:
        ['veto_regions-hwcemk7dbt-metadata.json']
        Found 1 files to upload:
        {'veto_regions-hwcemk7dbt-metadata.json'}
        ------
        Uploaded finished_data/051432-veto_regions-hwcemk7dbt to UC_MIDWAY_USERDISK with did xnt_051432:veto_regions-hwcemk7dbt.
        === Uploading time for veto_regions: 0.58 minutes ===
```