### PR TITLE
Debug when cuts_basic fail

### DIFF
--- a/outsource/workflow/runstrax.py
+++ b/outsource/workflow/runstrax.py
@@ -176,8 +176,10 @@ def process(runid,
                     st.make(runid_str, keystring,
                             save=keystring,
                             )
-                except:
+                except Exception as e:
                     print(f"Failed to make {keystring}, but it might be due to that the cuts are not ready yet. Skipping")
+                    print("Below is the error:")
+                    print(e)
             else:
                 st.make(runid_str, keystring,
                             save=keystring,


### PR DESCRIPTION
Sometime it might shoot error for cuts_basic for reasons beyond cuts not ready. We want to track what happened. 