### PR TITLE
Avoid regeneration of `.dbtoken` on job node

### DIFF
--- a/outsource/workflow/runstrax.py
+++ b/outsource/workflow/runstrax.py
@@ -24,9 +24,13 @@ import gc
 
 from admix.clients import rucio_client
 
+print("Initiing clients...")
 admix.clients._init_clients()
+print("Clients initiated")
 
+print("Initiing DB...")
 db = DB()
+print("DB initiated")
 
 # these dtypes we need to rechunk, so don't upload to rucio here!
 rechunk_dtypes = ['pulse_counts',
@@ -349,11 +353,15 @@ def main():
     except KeyError:
         print("No local RSE found")
 
+    print("Context is set up!")
+
     runid = args.dataset
     runid_str = "%06d" % runid
     out_dtype = args.output # eg. ypically for tpc: peaklets/event_info
 
+    print("Getting to-download list...")
     to_download = find_data_to_download(runid, out_dtype, st)
+    print("Got to-download list!")
 
     # see if we have rucio local frontend
     # if we do, it's probably more efficient to download data through the rucio frontend

--- a/outsource/workflow/strax-wrapper.sh
+++ b/outsource/workflow/strax-wrapper.sh
@@ -95,6 +95,10 @@ echo "--- Check RunDB API ---"
 echo "Pinging xenon-runsdb.grid.uchicago.edu"
 ping -c 5 xenon-runsdb.grid.uchicago.edu
 echo
+echo "Checking if we have .dbtoken"
+ls -lah $HOME/.dbtoken
+la -lah $USERPROFILE/.dbtoken
+echo 
 #echo "nmap xenon-runsdb.grid.uchicago.edu"
 #nmap -p5000 xenon-runsdb.grid.uchicago.edu
 #echo

--- a/outsource/workflow/strax-wrapper.sh
+++ b/outsource/workflow/strax-wrapper.sh
@@ -51,6 +51,7 @@ echo "Start dir is $start_dir. Here's whats inside:"
 ls -lah
 
 unset http_proxy
+export HOME=$PWD
 export XENON_CONFIG=$PWD/.xenon_config
 # do we still neeed these?
 export XDG_CACHE_HOME=${start_dir}/.cache
@@ -96,7 +97,9 @@ echo "Pinging xenon-runsdb.grid.uchicago.edu"
 ping -c 5 xenon-runsdb.grid.uchicago.edu
 echo
 echo "Checking if we have .dbtoken"
+echo "ls -lah $HOME/.dbtoken"
 ls -lah $HOME/.dbtoken
+echo "ls -lah $USERPROFILE/.dbtoken"
 la -lah $USERPROFILE/.dbtoken
 echo 
 #echo "nmap xenon-runsdb.grid.uchicago.edu"

--- a/outsource/workflow/strax-wrapper.sh
+++ b/outsource/workflow/strax-wrapper.sh
@@ -95,9 +95,9 @@ echo "--- Check RunDB API ---"
 echo "Pinging xenon-runsdb.grid.uchicago.edu"
 ping -c 5 xenon-runsdb.grid.uchicago.edu
 echo
-echo "nmap xenon-runsdb.grid.uchicago.edu"
-nmap -p5000 xenon-runsdb.grid.uchicago.edu
-echo
+#echo "nmap xenon-runsdb.grid.uchicago.edu"
+#nmap -p5000 xenon-runsdb.grid.uchicago.edu
+#echo
 
 echo 'Processing now...'
 

--- a/outsource/workflow/strax-wrapper.sh
+++ b/outsource/workflow/strax-wrapper.sh
@@ -92,7 +92,11 @@ fi
 echo
 
 echo "--- Check RunDB API ---"
+echo "Pinging xenon-runsdb.grid.uchicago.edu"
 ping -c 5 xenon-runsdb.grid.uchicago.edu
+echo
+echo "nmap xenon-runsdb.grid.uchicago.edu"
+nmap -p5000 xenon-runsdb.grid.uchicago.edu
 echo
 
 echo 'Processing now...'

--- a/outsource/workflow/strax-wrapper.sh
+++ b/outsource/workflow/strax-wrapper.sh
@@ -91,6 +91,10 @@ if [ -f ./$runid_pad*.tar.gz ]; then
 fi
 echo
 
+echo "--- Check RunDB API ---"
+ping -c 5 xenon-runsdb.grid.uchicago.edu
+echo
+
 echo 'Processing now...'
 
 chunkarg=""


### PR DESCRIPTION
This is a byproduct of exploration in #143 . 

In the past we were always regenerating `.dbtoken` on job node, because of the wrong `$HOME` directory to search for it. Now we overwrites `$HOME` so it can find the uploaded `.dbtoken` and avoid regeneration. Meanwhile, we added a bit more debug info regarding RunDB API, and turned off the not working `nmap` test. 