### PR TITLE
Debug combine wrapper

### DIFF
--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -392,7 +392,7 @@ class Outsource:
                     combine_job = self._job('combine', disk=self.job_kwargs['combine']['disk'])
                     combine_job.add_profiles(Namespace.CONDOR, 'requirements', requirements_us) # combine jobs must happen in the US
                     combine_job.add_profiles(Namespace.CONDOR, 'priority', str(dbcfg.priority)) # priority is given in the order they were submitted
-                    combine_job.add_inputs(combinepy, xenon_config, cutax_tarball)
+                    combine_job.add_inputs(combinepy, xenon_config, cutax_tarball, token)
                     combine_output_tar_name = f'{dbcfg.number:06d}-{dtype}-combined.tar.gz'
                     combine_output_tar = File(combine_output_tar_name)
                     combine_job.add_outputs(combine_output_tar, stage_out=(not self.upload_to_rucio))

--- a/outsource/workflow/combine-wrapper.sh
+++ b/outsource/workflow/combine-wrapper.sh
@@ -9,6 +9,8 @@ output=$4
 update_db=$5
 upload_to_rucio=$6
 
+export HOME=$PWD
+
 echo $*
 
 combine_extra_args=""

--- a/outsource/workflow/combine.py
+++ b/outsource/workflow/combine.py
@@ -21,9 +21,6 @@ from admix.clients import rucio_client
 
 admix.clients._init_clients()
 
-db = DB()
-
-
 def get_hashes(st):
     return {dt: item['hash'] for dt, item in st.provided_dtypes().items()}
 


### PR DESCRIPTION
Similar as aftershock of #144, initialization of `DB` will fail under `rundb_api_url = http://xenon-runsdb.grid.uchicago.edu:80`. So we have to correct the usage of `.dbtoken`.