### PR TITLE
Changed default to development

### DIFF
--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -33,7 +33,7 @@ from Pegasus.api import *
 #logging.basicConfig(level=config.logging_level)
 logger = logging.getLogger()
 
-DEFAULT_IMAGE = "/cvmfs/singularity.opensciencegrid.org/xenonnt/base-environment:latest"
+DEFAULT_IMAGE = "/cvmfs/singularity.opensciencegrid.org/xenonnt/base-environment:development"
 
 db = DB()
 


### PR DESCRIPTION
Since `latest` might be a bit too risky when processing, using `development` to reprocess is usually a better choice. 