### PR TITLE
Put back x509 proxy check

### DIFF
--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -210,8 +210,7 @@ class Outsource:
             pass
         
         # ensure we have a proxy with enough time left
-        # Temporarily turn off because of grid-proxy-info retired
-        #self._validate_x509_proxy()
+        self._validate_x509_proxy()
 
         # generate the workflow
         wf = self._generate_workflow()
@@ -566,7 +565,6 @@ class Outsource:
     def _validate_x509_proxy(self):
         '''
         ensure $HOME/user_cert exists and has enough time left.
-        This function has been retired because of the retired grid-proxy-info command in ap23 since June 2024
         '''
         logger.debug('Verifying that the ~/user_cert proxy has enough lifetime')
         min_valid_hours = 20


### PR DESCRIPTION
A followup in #155. We just reinstalled the `grid-proxy-info` on ap23.