### PR TITLE
No more local output

### DIFF
--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -545,7 +545,7 @@ class Outsource:
                 submit=not self.debug,
                 sites=['condorpool'],
                 staging_sites={'condorpool': 'staging-davs'},
-                output_sites=['local'],
+                output_sites=['staging-davs'],
                 dir=os.path.dirname(self.wf_dir),
                 relative_dir=self._wf_id
                )

--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -695,6 +695,11 @@ class Outsource:
         scratch_dir.add_file_servers(FileServer('gsidavs://xenon-gridftp.grid.uchicago.edu:2880/xenon/scratch/{}'.format(getpass.getuser()), Operation.ALL))
         staging_davs.add_directories(scratch_dir)
 
+        # output on davs
+        output_dir = Directory(Directory.LOCAL_STORAGE, path='/xenon/output/{}'.format(getpass.getuser()))
+        output_dir.add_file_servers(FileServer('gsidavs://xenon-gridftp.grid.uchicago.edu:2880/xenon/output/{}'.format(getpass.getuser()), Operation.ALL))
+        staging_davs.add_directories(output_dir)
+
         # condorpool
         condorpool = Site("condorpool")
         condorpool.add_profiles(Namespace.PEGASUS, style='condor')


### PR DESCRIPTION
When running in debug mode (we have to because of the [rucio direct upload issue unresolved](https://github.com/XENONnT/outsource/issues/137) ), it is a pain that we keep saturating our scratch folder locally. Since there is no more than two people running outsource, we can just make sure users delete stuff on davs constantly on their own, and it shall be safe.