### PR TITLE
Testing single thread processor

### DIFF
--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -374,7 +374,7 @@ class Outsource:
                 if dtype in PER_CHUNK_DTYPES:
                     # Set up the combine job first - we can then add to that job inside the chunk file loop
                     # only need combine job for low-level stuff
-                    combine_job = self._job('combine', disk=self.job_kwargs['combine']['disk'])
+                    combine_job = self._job('combine', disk=self.job_kwargs['combine']['disk'], cores=4)
                     combine_job.add_profiles(Namespace.CONDOR, 'requirements', requirements_us) # combine jobs must happen in the US
                     combine_job.add_profiles(Namespace.CONDOR, 'priority', str(dbcfg.priority)) # priority is given in the order they were submitted
                     combine_job.add_inputs(combinepy, xenon_config, cutax_tarball, token)

--- a/outsource/workflow/runstrax.py
+++ b/outsource/workflow/runstrax.py
@@ -178,7 +178,7 @@ def process(runid,
             if keystring == 'cuts_basic':
                 try:
                     st.make(runid_str, keystring,
-                            save=keystring,
+                            save=keystring, processor='single_thread'
                             )
                 except Exception as e:
                     print(f"Failed to make {keystring}, but it might be due to that the cuts are not ready yet. Skipping")
@@ -186,7 +186,7 @@ def process(runid,
                     print(e)
             else:
                 st.make(runid_str, keystring,
-                            save=keystring,
+                            save=keystring, processor='single_thread'
                         )
             print(f"DONE processing {keystring}")
                     


### PR DESCRIPTION
This is mandatory in new OSG situation (see [here](https://github.com/XENONnT/alea/pull/178) for a similar issue).

- Make sure `runstrax.py` always use single thread processor
- Give combine jobs 4 CPUs, in case we fail the CPU excessive usage error