### PR TITLE
Reduce transfer thread and one more core in event level jobs

### DIFF
--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -495,7 +495,7 @@ class Outsource:
                     job_output_tar = File('%06d-output-%s.tar.gz' % (dbcfg.number, dtype))
 
                     # Add job
-                    job = self._job(**self.job_kwargs[dtype])
+                    job = self._job(**self.job_kwargs[dtype], cores=2)
                     # https://support.opensciencegrid.org/support/solutions/articles/12000028940-working-with-tensorflow-gpus-and-containers
                     job.add_profiles(Namespace.CONDOR, 'requirements', requirements)
                     job.add_profiles(Namespace.CONDOR, 'priority', str(dbcfg.priority))

--- a/outsource/workflow/pegasus.conf
+++ b/outsource/workflow/pegasus.conf
@@ -19,7 +19,7 @@ dagman.maxidle = 5000
 #dagman.maxjobs = 300
 
 # transfer parallelism
-pegasus.transfer.threads = 4
+pegasus.transfer.threads = 1
 
 # Help Pegasus developers by sharing performance data (optional)
 pegasus.monitord.encoding = json


### PR DESCRIPTION
- Reduce transfer threads to follow the new OSG rules on CPU excessive usage
- Add one more core to event level jobs to see if it reduces problems in excessive usage