### PR TITLE
No longer need production if you don't even try to upload to rucio

### DIFF
--- a/outsource/Outsource.py
+++ b/outsource/Outsource.py
@@ -678,7 +678,8 @@ class Outsource:
         local.add_profiles(Namespace.ENV, PEGASUS_SUBMITTING_USER=os.environ['USER'])
         local.add_profiles(Namespace.ENV, X509_USER_PROXY=os.environ['HOME'] + '/user_cert')
         #local.add_profiles(Namespace.ENV, RUCIO_LOGGING_FORMAT="%(asctime)s  %(levelname)s  %(message)s")
-        local.add_profiles(Namespace.ENV, RUCIO_ACCOUNT='production')
+        if not self.debug:
+            local.add_profiles(Namespace.ENV, RUCIO_ACCOUNT='production')
         # improve python logging / suppress depreciation warnings (from gfal2 for example)
         local.add_profiles(Namespace.ENV, PYTHONUNBUFFERED='1')
         local.add_profiles(Namespace.ENV, PYTHONWARNINGS='ignore::DeprecationWarning')
@@ -721,7 +722,8 @@ class Outsource:
 
         condorpool.add_profiles(Namespace.ENV, PEGASUS_SUBMITTING_USER=os.environ['USER'])
         condorpool.add_profiles(Namespace.ENV, RUCIO_LOGGING_FORMAT="%(asctime)s  %(levelname)s  %(message)s")
-        condorpool.add_profiles(Namespace.ENV, RUCIO_ACCOUNT='production')
+        if not self.debug:
+            condorpool.add_profiles(Namespace.ENV, RUCIO_ACCOUNT='production')
 
         # improve python logging / suppress depreciation warnings (from gfal2 for example)
         condorpool.add_profiles(Namespace.ENV, PYTHONUNBUFFERED='1')

--- a/outsource/workflow/combine-wrapper.sh
+++ b/outsource/workflow/combine-wrapper.sh
@@ -44,7 +44,9 @@ echo
 # source the environment
 . /opt/XENONnT/setup.sh
 export XENON_CONFIG=$PWD/.xenon_config
-export RUCIO_ACCOUNT=production
+if [ "X$upload_to_rucio" = "Xtrue" ]; then
+    export RUCIO_ACCOUNT=production
+fi
 
 echo "--- Installing cutax ---"
 mkdir cutax

--- a/outsource/workflow/strax-wrapper.sh
+++ b/outsource/workflow/strax-wrapper.sh
@@ -44,9 +44,11 @@ if [ -e /image-build-info.txt ]; then
     cat /image-build-info.txt
     echo
 fi
-#
-export RUCIO_ACCOUNT=production
-#
+
+if [ "X$upload_to_rucio" = "Xtrue" ]; then
+    export RUCIO_ACCOUNT=production
+fi
+
 echo "Start dir is $start_dir. Here's whats inside:"
 ls -lah
 


### PR DESCRIPTION
Otherwise, you will fail at running `runstrax.py` if you don't have production proxy. This was too overkill before, and now everyone can use the grid to process things in debug mode.