### PR TITLE
Transfer data to local after processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ After installation and setting up the environment, it is time to submit jobs. Th
 usage: Outsource [-h] --context CONTEXT --xedocs_version XEDOCS_VERSION [--image IMAGE]
                  [--detector {all,tpc,muon_veto,neutron_veto}] [--workflow_id WORKFLOW_ID] [--ignore_processed]
                  [--debug] [--from NUMBER_FROM] [--to NUMBER_TO] [--run [RUN ...]] [--runlist RUNLIST] [--rucio_upload]
-                 [--rundb_update]
+                 [--rundb_update] [--local_transfer]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -182,6 +182,7 @@ optional arguments:
   --runlist RUNLIST     Path to a runlist file
   --rucio_upload        Upload data to rucio after processing
   --rundb_update        Update RunDB after processing
+  --local_transfer      Transfer data to local after processing
 ```
 
 This script requires at minimum the name of context (which must reside in the cutax version installed in the environment you are in). If no other arguments are passed, this script will try to find all data that can be processed, and process it. Some inputs from the configuration file at environmental variable `XENON_CONFIG` are also used, specifically:

--- a/outsource/scripts/submit.py
+++ b/outsource/scripts/submit.py
@@ -75,7 +75,7 @@ def main():
     )
     parser.add_argument(
         "--local_transfer",
-        dest="transfer_to_local",
+        dest="local_transfer",
         action="store_true",
         help="Transfer data to local after processing",
     )

--- a/outsource/scripts/submit.py
+++ b/outsource/scripts/submit.py
@@ -73,6 +73,12 @@ def main():
         action="store_true",
         help="Update RunDB after processing",
     )
+    parser.add_argument(
+        "--local_transfer",
+        dest="transfer_to_local",
+        action="store_true",
+        help="Transfer data to local after processing",
+    )
     args = parser.parse_args()
 
     if args.ignore_processed and args.rucio_upload:
@@ -121,6 +127,7 @@ def main():
         rucio_upload=args.rucio_upload,
         rundb_update=args.rundb_update,
         ignore_processed=args.ignore_processed,
+        local_transfer=args.local_transfer,
         debug=args.debug,
     )
 

--- a/outsource/submitter.py
+++ b/outsource/submitter.py
@@ -282,27 +282,25 @@ class Submitter:
         else:
             # staging site - davs
             staging_davs = Site("staging-davs")
+            scratch_dir_path = f"/xenon/scratch/{getpass.getuser()}/{self.workflow_id}"
             scratch_dir = Directory(
-                Directory.SHARED_SCRATCH, path=f"/xenon/scratch/{getpass.getuser()}"
+                Directory.SHARED_SCRATCH,
+                path=scratch_dir_path,
             )
             scratch_dir.add_file_servers(
                 FileServer(
-                    (
-                        "gsidavs://xenon-gridftp.grid.uchicago.edu:2880"
-                        f"/xenon/scratch/{getpass.getuser()}"
-                    ),
+                    f"gsidavs://xenon-gridftp.grid.uchicago.edu:2880{scratch_dir_path}",
                     Operation.ALL,
                 )
             )
+            output_dir_path = f"/xenon/output/{getpass.getuser()}/{self.workflow_id}"
             output_dir = Directory(
-                Directory.LOCAL_STORAGE, path=f"/xenon/output/{getpass.getuser()}"
+                Directory.LOCAL_STORAGE,
+                path=output_dir_path,
             )
             output_dir.add_file_servers(
                 FileServer(
-                    (
-                        "gsidavs://xenon-gridftp.grid.uchicago.edu:2880"
-                        f"/xenon/output/{getpass.getuser()}"
-                    ),
+                    f"gsidavs://xenon-gridftp.grid.uchicago.edu:2880{output_dir_path}",
                     Operation.ALL,
                 )
             )

--- a/outsource/submitter.py
+++ b/outsource/submitter.py
@@ -616,7 +616,7 @@ class Submitter:
                         )
 
                         job.add_inputs(installsh, processpy, xenon_config, token, *tarballs)
-                        job.add_outputs(job_tar, stage_out=not self.rucio_upload)
+                        job.add_outputs(job_tar, stage_out=False)
                         wf.add_jobs(job)
 
                         # All strax jobs depend on the pre-flight or a download job,


### PR DESCRIPTION
Close: https://github.com/XENONnT/outsource/issues/186

If using `--local_transfer`, the processed data will be transferred back to the workflow folder in `/xenon/scratch/`whoami``.

For example, `outsource --context xenonnt_offline --xedocs_version global_v16 --image el9.2024.09.1 --run 53018 --ignore_processed`.

This is accomplished by:

1. set `output_sites` argument of job submission to `"local"` if `local_transfer` is `True`, otherwise `"staging-davs"`.
2. if `local_transfer` is `False`, we do not need to initialize `"local"` site.