### PR TITLE
Check if there is no crucial user installed package

### DIFF
--- a/outsource/submitter.py
+++ b/outsource/submitter.py
@@ -356,7 +356,15 @@ class Submitter:
         check_package_names = uconfig.getlist(
             "Outsource", "check_user_install_package", fallback=[]
         )
-        check_package_names += ["strax", "straxen", "cutax", "utilix", "admix", "outsource"]
+        check_package_names += [
+            "strax",
+            "straxen",
+            "cutax",
+            "rucio",
+            "utilix",
+            "admix",
+            "outsource",
+        ]
         for package_name in set(check_package_names) - set(package_names):
             if Tarball.get_installed_git_repo(package_name) or Tarball.is_user_installed(
                 package_name

--- a/outsource/submitter.py
+++ b/outsource/submitter.py
@@ -345,7 +345,30 @@ class Submitter:
         """Make tarballs of Ax-based packages if they are in editable user-installed mode."""
         tarballs = []
         tarball_paths = []
-        for package_name in ["strax", "straxen", "cutax", "utilix", "outsource"]:
+
+        package_names = uconfig.getlist("Outsource", "user_install_package", fallback=[])
+        if "cutax" not in package_names:
+            raise RuntimeError(
+                "cutax must be in the list of user_install_package "
+                f"in the XENON_CONFIG configuration, but got {package_names}."
+            )
+        # Check if the package in not in the official software environment
+        check_package_names = uconfig.getlist(
+            "Outsource", "check_user_install_package", fallback=[]
+        )
+        check_package_names += ["strax", "straxen", "cutax", "utilix", "admix", "outsource"]
+        for package_name in set(check_package_names) - set(package_names):
+            if Tarball.get_installed_git_repo(package_name) or Tarball.is_user_installed(
+                package_name
+            ):
+                raise RuntimeError(
+                    f"{package_name} should be either in user_install_package "
+                    "in the XENON_CONFIG configuration after being installed in editable mode, "
+                    "because it is not in the official software environment. "
+                    "Or uninstalled from the user-installed environment."
+                )
+        # Install the specified user-installed packages
+        for package_name in package_names:
             _tarball = Tarball(self.generated_dir, package_name)
             if not Tarball.get_installed_git_repo(package_name):
                 # Packages should not be non-editable user-installed


### PR DESCRIPTION
Add a list of packages that should be user-installed

Close: https://github.com/XENONnT/outsource/issues/74

This PR is implemented as https://github.com/XENONnT/outsource/issues/74#issuecomment-2378272461.

1. If you want to self-install a package, put it in the `user_install_package` section of  `Outsource` in the XENON_CONFIG configuration.
2. If you want to check whether a package is self-installed but not included in the workflow(will not installed on the computing node), put it in the `check_user_install_package` section of  `Outsource` in the XENON_CONFIG configuration.

Depends on https://github.com/XENONnT/utilix/pull/133