### PR TITLE
Download `raw_records*` from only `raw_records_rse`

### DIFF
--- a/outsource/workflow/combine.py
+++ b/outsource/workflow/combine.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import shutil
 import admix
+from utilix import uconfig
 from utilix.config import setup_logger
 import strax
 import straxen
@@ -76,7 +77,17 @@ def main():
     st.storage = [
         strax.DataDirectory(input_path, readonly=True),
         strax.DataDirectory(output_path),  # where we are copying data to
-        straxen.storage.RucioRemoteFrontend(staging_dir=staging_dir, download_heavy=False),
+        straxen.storage.RucioRemoteFrontend(
+            staging_dir=staging_dir,
+            download_heavy=True,
+            take_only=tuple(st.root_data_types),
+            rses_only=uconfig.getlist("Outsource", "raw_records_rse"),
+        ),
+        straxen.storage.RucioRemoteFrontend(
+            staging_dir=staging_dir,
+            download_heavy=True,
+            exclude=tuple(st.root_data_types),
+        ),
     ]
 
     # Check what data is in the output folder

--- a/outsource/workflow/process.py
+++ b/outsource/workflow/process.py
@@ -4,6 +4,7 @@ import sys
 import time
 import shutil
 import gc
+from utilix import uconfig
 from utilix.config import setup_logger
 import admix
 import strax
@@ -78,9 +79,18 @@ def main():
         straxen.storage.RucioRemoteFrontend(
             staging_dir=staging_dir,
             download_heavy=True,
-            take_only=tuple(st.root_data_types) if args.ignore_processed else tuple(),
+            take_only=tuple(st.root_data_types),
+            rses_only=uconfig.getlist("Outsource", "raw_records_rse"),
         ),
     ]
+    if not args.ignore_processed:
+        st.storage + [
+            straxen.storage.RucioRemoteFrontend(
+                staging_dir=staging_dir,
+                download_heavy=True,
+                exclude=tuple(st.root_data_types),
+            ),
+        ]
 
     # Add local frontend if we can
     # This is a temporary hack

--- a/outsource/workflow/untar.sh
+++ b/outsource/workflow/untar.sh
@@ -9,11 +9,13 @@ outputs_dir=$2
 # Sanity check: these are the files in the output directory
 ls -lh $outputs_dir
 
+decompressed=$outputs_dir/decompressed-${tar_filename%%.*}
+
 # Make a temporary directory for decompressed files
-mkdir -p $outputs_dir/decompressed
+mkdir -p $decompressed
 
 # Untar the output file
-tar -xzf $tar_filename -C $outputs_dir/decompressed --strip-components=1
+tar -xzf $tar_filename -C $decompressed --strip-components=1
 rm $tar_filename
 
 # Check the output
@@ -21,7 +23,8 @@ echo "Checking the output"
 ls -lh
 
 # Move the outputs
-mv $outputs_dir/decompressed/* $outputs_dir/
+mv $decompressed/* $outputs_dir/
+rm -r $decompressed
 
 # Goodbye
 echo "Done. Exiting."


### PR DESCRIPTION
Close: https://github.com/XENONnT/outsource/issues/93

1. Download `raw_records*` from `raw_records_rse`.
2. Download other things if not `ignore_processed`.