### PR TITLE
Limit the number CPU usage of JAX and TensorFlow

### DIFF
--- a/outsource/workflow/process-wrapper.sh
+++ b/outsource/workflow/process-wrapper.sh
@@ -123,7 +123,13 @@ export OPENBLAS_NUM_THREADS=1
 export BLIS_NUM_THREADS=1
 export NUMEXPR_NUM_THREADS=1
 export GOTO_NUM_THREADS=1
+# Limiting CPU usage of TensorFlow
+export TF_NUM_INTRAOP_THREADS=1
+export TF_NUM_INTEROP_THREADS=1
+# For unknown reason, this does not work on limiting CPU usage of JAX
 export XLA_FLAGS="--xla_cpu_multi_thread_eigen=false intra_op_parallelism_threads=1"
+# But this works, from https://github.com/jax-ml/jax/discussions/22739
+export NPROC=1
 
 echo "Processing:"
 time python3 process.py $run_id --context $context --xedocs_version $xedocs_version --chunks_start $chunks_start --chunks_end $chunks_end --input_path $input_path --output_path $output_path --data_types $data_types $extraflags


### PR DESCRIPTION
Close: https://github.com/XENONnT/outsource/issues/205

Thank @juehang and @rynge  for looking for the reason and providing the solution.

For the issue of JAX, unfortunately, this TODO is still a TODO: https://github.com/openxla/xla/blob/8d7f72345ce58ce959dcc99f2b1a13e5c672b3e9/xla/pjrt/utils.cc#L817.

Related [slack thread](https://xenonnt.slack.com/archives/C016UJZ090B/p1728527855644359)