### PR TITLE
Optimize the order of data_types in processing

### DIFF
--- a/outsource/scripts/submit.py
+++ b/outsource/scripts/submit.py
@@ -57,7 +57,7 @@ def main():
     parser.add_argument("--from", dest="number_from", type=int, help="Run number to start with")
     parser.add_argument("--to", dest="number_to", type=int, help="Run number to end with")
     parser.add_argument(
-        "--run", nargs="*", type=int, help="Space separated specific run number(s) to process"
+        "--run", nargs="*", type=int, help="Space separated specific run_id(s) to process"
     )
     parser.add_argument("--runlist", type=str, help="Path to a runlist file")
     parser.add_argument(
@@ -108,7 +108,7 @@ def main():
     )
     if set(_runlist) - set(runlist):
         logger.warning(
-            "The following run numbers were not processible "
+            "The following run_ids were not processible "
             f"after checking dependeicies in the RunDB: {set(_runlist) - set(runlist)}"
         )
     if not runlist:

--- a/outsource/utils.py
+++ b/outsource/utils.py
@@ -62,10 +62,10 @@ def get_runlist(
     Check if dependencies are available in RunDB.
     :param st: straxen context
     :param detector: detector to process
-    :param number_from: start run number
-    :param number_to: end run number
-    :param runlist: list of run numbers to process
-    :return: list of run numbers
+    :param number_from: start run_id
+    :param number_to: end run_id
+    :param runlist: list of run_ids to process
+    :return: list of run_ids
 
     """
     include_modes = uconfig.getlist("Outsource", "include_modes", fallback=[])
@@ -188,13 +188,13 @@ def get_runlist(
         raise ValueError("Nothing was found in RunDB for even the most basic requirement.")
 
     runlist_basic_has_raw = [r["number"] for r in cursor_basic_has_raw]
-    logger.warning(
-        "The following are the run numbers passing the basic queries and "
+    logger.info(
+        "The following are the run_ids passing the basic queries and "
         f"have raw data available: {runlist_basic_has_raw}"
     )
     runlist_basic_to_save = [r["number"] for r in cursor_basic_to_save]
-    logger.warning(
-        "The following are the run numbers passing the basic queries and "
+    logger.info(
+        "The following are the run_ids passing the basic queries and "
         f"have to be processed: {runlist_basic_to_save}"
     )
 

--- a/outsource/workflow/combine.py
+++ b/outsource/workflow/combine.py
@@ -17,7 +17,7 @@ def merge(st, run_id, data_type, chunk_number_group):
     """Merge per-chunk storage for a given data_type.
 
     :param st: straxen context
-    :param run_id: run number padded with 0s
+    :param run_id: run_id padded with 0s
     :param data_type: data_type to be merged
     :param chunk_number_group: list of chunk number to merge.
 

--- a/outsource/workflow/process.py
+++ b/outsource/workflow/process.py
@@ -98,7 +98,7 @@ def main():
         return
 
     # Get the order of data_types in processing
-    data_types = get_processing_order(data_types)
+    data_types = get_processing_order(st, data_types, rm_lower=chunks is None)
 
     logger.info(f"To process: {data_types}")
     for data_type in data_types:

--- a/outsource/workflow/process.py
+++ b/outsource/workflow/process.py
@@ -6,8 +6,7 @@ import gc
 from utilix import uconfig
 from utilix.config import setup_logger
 
-from outsource.meta import PER_CHUNK_DATA_TYPES
-from outsource.utils import get_context, get_to_save_data_types, per_chunk_storage_root_data_type
+from outsource.utils import get_context, get_processing_order, per_chunk_storage_root_data_type
 from outsource.upload import upload_to_rucio
 
 
@@ -98,17 +97,8 @@ def main():
         st.get_array(run_id, data_types, chunk_number=chunk_number)
         return
 
-    data_types = get_to_save_data_types(st, data_types)
-    if chunks:
-        # Remove all data_types to be saved when processing the dependencies of PER_CHUNK_DATA_TYPES
-        per_chunk_dependencies = list(
-            set().union(*[st.get_dependencies(d) for d in PER_CHUNK_DATA_TYPES])
-        )
-    else:
-        # Remove all data_types to be saved when processing PER_CHUNK_DATA_TYPES
-        per_chunk_dependencies = PER_CHUNK_DATA_TYPES
-    data_types -= get_to_save_data_types(st, per_chunk_dependencies)
-    data_types = sorted(data_types, key=lambda x: st.tree_levels[x]["order"])
+    # Get the order of data_types in processing
+    data_types = get_processing_order(data_types)
 
     logger.info(f"To process: {data_types}")
     for data_type in data_types:


### PR DESCRIPTION
For example, event_pattern_fit depends on `event_area_per_channel`:
https://github.com/XENONnT/straxen/blob/764f14cbc16c8633e176ca8c0a93c589293c24e0/straxen/plugins/events/event_pattern_fit.py#L15. `event_area_per_channel` is not always saved, but while processing `event_area_per_channel`, `event_n_channel` will be saved. In this case, even though `event_n_channel` is lower than `event_pattern_fit`, we should not directly process `event_n_channel`. Instead, we should process `event_area_per_channel` first.

`utils.get_processing_order` does this.