### PR TITLE
Set environmental variable of CPUs usage for all jobs

### DIFF
--- a/outsource/submitter.py
+++ b/outsource/submitter.py
@@ -294,6 +294,21 @@ class Submitter:
         # Improve python logging / suppress depreciation warnings (from gfal2 for example)
         condorpool.add_profiles(Namespace.ENV, PYTHONUNBUFFERED="1")
         condorpool.add_profiles(Namespace.ENV, PYTHONWARNINGS="ignore::DeprecationWarning")
+        condorpool.add_profiles(Namespace.ENV, MKL_NUM_THREADS="1")
+        condorpool.add_profiles(Namespace.ENV, OPENBLAS_NUM_THREADS="1")
+        condorpool.add_profiles(Namespace.ENV, BLIS_NUM_THREADS="1")
+        condorpool.add_profiles(Namespace.ENV, NUMEXPR_NUM_THREADS="1")
+        condorpool.add_profiles(Namespace.ENV, GOTO_NUM_THREADS="1")
+        # Limiting CPU usage of TensorFlow
+        condorpool.add_profiles(Namespace.ENV, TF_NUM_INTRAOP_THREADS="1")
+        condorpool.add_profiles(Namespace.ENV, TF_NUM_INTEROP_THREADS="1")
+        # For unknown reason, this does not work on limiting CPU usage of JAX
+        condorpool.add_profiles(
+            Namespace.ENV,
+            XLA_FLAGS="--xla_cpu_multi_thread_eigen=false intra_op_parallelism_threads=1",
+        )
+        # But this works, from https://github.com/jax-ml/jax/discussions/22739
+        condorpool.add_profiles(Namespace.ENV, NPROC="1")
 
         # staging site - davs
         staging_davs = Site("staging-davs")
@@ -683,7 +698,7 @@ class Submitter:
             )
 
             job.add_inputs(installsh, processpy, xenon_config, token, *tarballs)
-            job.add_outputs(job_tar, stage_out=False)
+            job.add_outputs(job_tar, stage_out=True)
             job.set_stdout(File(f"{job_tar}.log"), stage_out=True)
 
             # All strax jobs depend on the pre-flight or a download job,

--- a/outsource/workflow/combine-wrapper.sh
+++ b/outsource/workflow/combine-wrapper.sh
@@ -78,13 +78,6 @@ echo
 echo "Total amount of data before combine: "`du -s --si $input_path | cut -f1`
 echo
 
-export OMP_NUM_THREADS=1
-export MKL_NUM_THREADS=1
-export OPENBLAS_NUM_THREADS=1
-export BLIS_NUM_THREADS=1
-export NUMEXPR_NUM_THREADS=1
-export GOTO_NUM_THREADS=1
-
 echo "Combining:"
 time python3 combine.py $run_id --context $context --xedocs_version $xedocs_version --input_path $input_path --output_path $output_path $chunksarg $extraflags
 

--- a/outsource/workflow/process-wrapper.sh
+++ b/outsource/workflow/process-wrapper.sh
@@ -117,20 +117,6 @@ echo
 # map -p5000 xenon-runsdb.grid.uchicago.edu
 # echo
 
-export OMP_NUM_THREADS=1
-export MKL_NUM_THREADS=1
-export OPENBLAS_NUM_THREADS=1
-export BLIS_NUM_THREADS=1
-export NUMEXPR_NUM_THREADS=1
-export GOTO_NUM_THREADS=1
-# Limiting CPU usage of TensorFlow
-export TF_NUM_INTRAOP_THREADS=1
-export TF_NUM_INTEROP_THREADS=1
-# For unknown reason, this does not work on limiting CPU usage of JAX
-export XLA_FLAGS="--xla_cpu_multi_thread_eigen=false intra_op_parallelism_threads=1"
-# But this works, from https://github.com/jax-ml/jax/discussions/22739
-export NPROC=1
-
 echo "Processing:"
 time python3 process.py $run_id --context $context --xedocs_version $xedocs_version --chunks_start $chunks_start --chunks_end $chunks_end --input_path $input_path --output_path $output_path --data_types $data_types $extraflags
 


### PR DESCRIPTION
Sometimes, a "combine" job also uses more than one CPU. This is CPU dependent so it will not always happen.

This PR limits the CPU for all jobs to one.