### PR TITLE
Ask reporter to include the `Outsource` section of `XENON_CONFIG`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,5 +10,6 @@ assignees: ''
 **Describe the bug**
 
 **To Reproduce**
+Please include `Outsource` section of `XENON_CONFIG`. Do not include `RunDB` section because it is confidential.
 
 **Expected behavior**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,5 +10,6 @@ assignees: ''
 **Is your feature request related to an issue?**
 
 **Describe the requested feature**
+Please include the version of softwares you use. Please also include `Outsource` section of `XENON_CONFIG` if necessary. Do not include `RunDB` section because it is confidential.
 
 **Describe your (preliminary) solution if there is one**


### PR DESCRIPTION
This small update prevents confusion similar to https://github.com/XENONnT/outsource/issues/218#issuecomment-2415355590.