### PR TITLE
Allow staging-out lower `data_types` and keeping downloaded `raw_records*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,10 @@ After installation and setting up the environment, it is time to submit jobs. Th
 
 ```
 [whoami@ap23 ~]$ outsource --help
-usage: Outsource [-h] --context CONTEXT --xedocs_version XEDOCS_VERSION [--image IMAGE] [--detector {all,tpc,muon_veto,neutron_veto}]
-                 [--workflow_id WORKFLOW_ID] [--ignore_processed] [--debug] [--from NUMBER_FROM] [--to NUMBER_TO] [--run [RUN ...]]
-                 [--runlist RUNLIST] [--rucio_upload] [--rundb_update] [--local_transfer] [--keep_dbtoken]
+usage: Outsource [-h] --context CONTEXT --xedocs_version XEDOCS_VERSION [--image IMAGE]
+                 [--detector {all,tpc,muon_veto,neutron_veto}] [--workflow_id WORKFLOW_ID] [--ignore_processed] [--debug]
+                 [--from NUMBER_FROM] [--to NUMBER_TO] [--run [RUN ...]] [--runlist RUNLIST] [--rucio_upload] [--rundb_update]
+                 [--local_transfer] [--keep_dbtoken] [--stage_out_lower]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -184,6 +185,7 @@ optional arguments:
   --rundb_update        Update RunDB after processing
   --local_transfer      Transfer data to local after processing
   --keep_dbtoken        Do not renew .dbtoken
+  --stage_out_lower     Whether to stage out the results of lower level processing
 ```
 
 This script requires at minimum the name of context (which must reside in the cutax version installed in the environment you are in). If no other arguments are passed, this script will try to find all data that can be processed, and process it. Some inputs from the configuration file at environmental variable `XENON_CONFIG` are also used, specifically:

--- a/outsource/scripts/submit.py
+++ b/outsource/scripts/submit.py
@@ -84,6 +84,12 @@ def main():
         action="store_true",
         help="Do not renew .dbtoken",
     )
+    parser.add_argument(
+        "--stage_out_lower",
+        dest="stage_out_lower",
+        action="store_true",
+        help="Whether to stage out the results of lower level processing",
+    )
     args = parser.parse_args()
 
     if not args.keep_dbtoken:
@@ -142,6 +148,7 @@ def main():
         rundb_update=args.rundb_update,
         ignore_processed=args.ignore_processed,
         local_transfer=args.local_transfer,
+        stage_out_lower=args.stage_out_lower,
         debug=args.debug,
     )
 

--- a/outsource/workflow/combine.py
+++ b/outsource/workflow/combine.py
@@ -44,6 +44,7 @@ def main():
     parser.add_argument("--output_path", required=True)
     parser.add_argument("--rucio_upload", action="store_true", dest="rucio_upload")
     parser.add_argument("--rundb_update", action="store_true", dest="rundb_update")
+    parser.add_argument("--keep_raw_records", action="store_true", dest="keep_raw_records")
     parser.add_argument("--chunks", required=True, nargs="*", type=int)
 
     args = parser.parse_args()
@@ -68,7 +69,7 @@ def main():
     )
 
     # Check what data is in the output folder
-    data_types = [d.split("-")[1] for d in os.listdir(input_path)]
+    data_types = sorted(set([d.split("-")[1] for d in os.listdir(input_path)]))
 
     _chunks = [0] + args.chunks
     chunk_number_group = [list(range(_chunks[i], _chunks[i + 1])) for i in range(len(args.chunks))]
@@ -79,7 +80,8 @@ def main():
         merge(st, run_id, data_type, chunk_number_group)
 
     # Remove rucio directory
-    shutil.rmtree(staging_dir)
+    if not args.keep_raw_records:
+        shutil.rmtree(staging_dir)
 
     if not args.rucio_upload:
         logger.warning("Ignoring rucio upload")

--- a/outsource/workflow/process.py
+++ b/outsource/workflow/process.py
@@ -54,6 +54,7 @@ def main():
     parser.add_argument("--ignore_processed", action="store_true", dest="ignore_processed")
     parser.add_argument("--download_only", action="store_true", dest="download_only")
     parser.add_argument("--no_download", action="store_true", dest="no_download")
+    parser.add_argument("--keep_raw_records", action="store_true", dest="keep_raw_records")
 
     args = parser.parse_args()
 
@@ -100,6 +101,9 @@ def main():
     # Get the order of data_types in processing
     data_types = get_processing_order(st, data_types, rm_lower=chunks is None)
 
+    if not data_types:
+        raise ValueError("No data types to process, something is wrong")
+
     logger.info(f"To process: {data_types}")
     for data_type in data_types:
         logger.info(f"Processing: {data_type}")
@@ -109,7 +113,8 @@ def main():
     logger.info("Done processing. Now check if we should upload to rucio")
 
     # Remove rucio directory
-    shutil.rmtree(staging_dir)
+    if not args.keep_raw_records:
+        shutil.rmtree(staging_dir)
 
     # Now loop over data_type we just made and upload the data
     processed_data = os.listdir(output_path)


### PR DESCRIPTION
1. Add `--stage_out_lower` to download the lower level reprocessing result.
2. Add `--keep_raw_records ` to keep the downloaded `raw_records*`.