### PR TITLE
Decide whether the dependency exists based on specified RSE

### DIFF
--- a/outsource/config.py
+++ b/outsource/config.py
@@ -229,7 +229,7 @@ class RunConfig:
                 data["type"] == data_type
                 and data["host"] == "rucio-catalogue"
                 and data["status"] == "transferred"
-                and data["location"] != "LNGS_USERDISK"
+                and data["location"] in uconfig.getlist("Outsource", "raw_records_rse")
                 and "TAPE" not in data["location"]
             ):
                 return True


### PR DESCRIPTION
We limited the site of RSE of `RucioRemoteFrontend` to be `raw_records_rse` in https://github.com/XENONnT/outsource/blob/4f6e5b07e7bd65a07b8e4866c7cbc1d13ddf1b60/outsource/utils.py#L38. So we also need to decide whether the dependency exists based on `raw_records_rse`.