### PR TITLE
Fix bug when multiple json files exists

### DIFF
--- a/outsource/workflow/combine-wrapper.sh
+++ b/outsource/workflow/combine-wrapper.sh
@@ -82,8 +82,10 @@ echo "Combining:"
 time python3 combine.py $run_id --context $context --xedocs_version $xedocs_version --input_path $input_path --output_path $output_path $chunksarg $extraflags
 
 echo "Moving auxiliary files to output directory"
-[ -e *.npy ] && mv *.npy $output_path
-[ -e *.json ] && mv *.json $output_path
+if ls $input_path/*.npy >/dev/null 2>&1; then mv $input_path/*.npy $output_path; fi
+if ls $input_path/*.json >/dev/null 2>&1; then mv $input_path/*.json $output_path; fi
+if ls *.npy >/dev/null 2>&1; then mv *.npy $output_path; fi
+if ls *.json >/dev/null 2>&1; then mv *.json $output_path; fi
 
 echo "Removing inputs directory:"
 rm -r $input_path

--- a/outsource/workflow/process-wrapper.sh
+++ b/outsource/workflow/process-wrapper.sh
@@ -121,10 +121,10 @@ echo "Processing:"
 time python3 process.py $run_id --context $context --xedocs_version $xedocs_version --chunks_start $chunks_start --chunks_end $chunks_end --input_path $input_path --output_path $output_path --data_types $data_types $extraflags
 
 echo "Moving auxiliary files to output directory"
-[ -e *.npy ] && mv *.npy $output_path
-[ -e *.json ] && mv *.json $output_path
-[ -e $input_path/*.npy ] && mv $input_path/*.npy $output_path
-[ -e $input_path/*.json ] && mv $input_path/*.json $output_path
+if ls $input_path/*.npy >/dev/null 2>&1; then mv $input_path/*.npy $output_path; fi
+if ls $input_path/*.json >/dev/null 2>&1; then mv $input_path/*.json $output_path; fi
+if ls *.npy >/dev/null 2>&1; then mv *.npy $output_path; fi
+if ls *.json >/dev/null 2>&1; then mv *.json $output_path; fi
 
 echo "Removing inputs directory:"
 rm -r $input_path

--- a/outsource/workflow/test_resource_usage.py
+++ b/outsource/workflow/test_resource_usage.py
@@ -60,11 +60,11 @@ def wrapper(func):
 if only_combine:
     outsource.workflow.combine.merge = wrapper(outsource.workflow.combine.merge)
     mem = memory_usage(proc=combine_main, interval=0.1, timestamps=True)
-    prefix = "combine"
+    prefix = f"{args.run_id:06d}_combine"
 else:
     outsource.workflow.process.process = wrapper(outsource.workflow.process.process)
     mem = memory_usage(proc=process_main, interval=0.1, timestamps=True)
-    prefix = "process"
+    prefix = f"{args.run_id:06d}_process"
 mem = np.array(mem)
 
 
@@ -93,8 +93,8 @@ storage_usage = get_sizes("./")
 if time_usage:
     logger.info(f"Max memory usage: {mem[:, 0].max():.1f} MB")
     logger.info(f"Max storage usage: {storage_usage[os.path.abspath('./')] / 1e6:.1f} MB")
-    np.save(f"{args.run_id:06d}_{prefix}_memory_usage_{suffix}.npy", mem)
-    with open(f"{args.run_id:06d}_{prefix}_time_usage_{suffix}.json", mode="w") as f:
+    np.save(f"{prefix}_memory_usage_{suffix}.npy", mem)
+    with open(f"{prefix}_time_usage_{suffix}.json", mode="w") as f:
         f.write(json.dumps(time_usage, indent=4))
-    with open(f"{args.run_id:06d}_{prefix}_storage_usage_{suffix}.json", mode="w") as f:
+    with open(f"{prefix}_storage_usage_{suffix}.json", mode="w") as f:
         f.write(json.dumps(storage_usage, indent=4))


### PR DESCRIPTION
Previously when there are multiple json files existed, you might see errors like:
```
bash: [: 053018_process_storage_usage_lower_tpc_0_1.json: binary operator expected
```
.