### PR TITLE
Prioritize the first assign RSE

### DIFF
--- a/outsource/config.py
+++ b/outsource/config.py
@@ -417,15 +417,16 @@ class RunConfig:
 
         """
 
-        for data in self.run_data:
-            if (
-                data["type"] == data_type
-                and data["host"] == "rucio-catalogue"
-                and data["status"] == "transferred"
-                and data["location"] in uconfig.getlist("Outsource", "raw_records_rses")
-                and "TAPE" not in data["location"]
-            ):
-                return data
+        for rse in uconfig.getlist("Outsource", "raw_records_rses"):
+            for data in self.run_data:
+                if (
+                    data["type"] == data_type
+                    and data["host"] == "rucio-catalogue"
+                    and data["status"] == "transferred"
+                    and data["location"] == rse
+                    and "TAPE" not in data["location"]
+                ):
+                    return data
         return False
 
     def list_files(self, data_type, verbose=False):


### PR DESCRIPTION
Sometimes the data can exist on multiple RSEs. But usually, we should send the job to nodes connected to `UC_OSG_USERDISK`. This PR make sure that the first RSE in `raw_records_rses` is priorities.