### PR TITLE
Small updates and fixes

### DIFF
--- a/outsource/config.py
+++ b/outsource/config.py
@@ -48,7 +48,7 @@ class RunConfig:
     """
 
     # Data availability to site selection map.
-    # This puts constraints on the sites that can be used for 
+    # This puts constraints on the sites that can be used for
     # processing based on the input RSE for raw_records.
     rse_site_map = {
         "UC_OSG_USERDISK": {"expr": 'GLIDEIN_Country == "US"'},
@@ -405,7 +405,6 @@ class RunConfig:
                             self.data_types[detector][label][prefix + md] = _data_types
                         else:
                             self.data_types[detector][label][prefix + md] = _data_types.tolist()
-
 
     def dependency_exists(self, data_type="raw_records"):
         """Returns a boolean for whether the dependency exists in rucio and is accessible.

--- a/outsource/config.py
+++ b/outsource/config.py
@@ -48,7 +48,8 @@ class RunConfig:
     """
 
     # Data availability to site selection map.
-    # site mean condor will try to run the job on those sites
+    # This puts constraints on the sites that can be used for 
+    # processing based on the input RSE for raw_records.
     rse_site_map = {
         "UC_OSG_USERDISK": {"expr": 'GLIDEIN_Country == "US"'},
         "UC_DALI_USERDISK": {"expr": 'GLIDEIN_Country == "US"'},
@@ -57,9 +58,9 @@ class RunConfig:
         "CNAF_TAPE_USERDISK": {},
         "CNAF_USERDISK": {},
         "LNGS_USERDISK": {},
-        "NIKHEF2_USERDISK": {"site": "NIKHEF", "expr": 'GLIDEIN_Site == "NIKHEF"'},
-        "NIKHEF_USERDISK": {"site": "NIKHEF", "expr": 'GLIDEIN_Site == "NIKHEF"'},
-        "SURFSARA_USERDISK": {"site": "SURFsara", "expr": 'GLIDEIN_Site == "SURFsara"'},
+        "NIKHEF2_USERDISK": {"site": "NIKHEF", "expr": 'GLIDEIN_Country == "NL"'},
+        "NIKHEF_USERDISK": {"site": "NIKHEF", "expr": 'GLIDEIN_Country == "NL"'},
+        "SURFSARA_USERDISK": {"site": "SURFsara", "expr": 'GLIDEIN_Country == "NL"'},
         "WEIZMANN_USERDISK": {"site": "Weizmann", "expr": 'GLIDEIN_Site == "Weizmann"'},
         "SDSC_USERDISK": {"expr": 'GLIDEIN_ResourceName == "SDSC-Expanse"'},
         "SDSC_NSDF_USERDISK": {"expr": 'GLIDEIN_Country == "US"'},

--- a/outsource/config.py
+++ b/outsource/config.py
@@ -399,12 +399,10 @@ class RunConfig:
                     for prefix in ["", "combine_"]:
                         if prefix + md not in self.data_types[detector][label]:
                             continue
-                        self.data_types[detector][label][prefix + md] *= _detector["redundancy"][md]
-                        _data_types = self.data_types[detector][label][prefix + md]
-                        if isinstance(_data_types, float):
-                            self.data_types[detector][label][prefix + md] = _data_types
-                        else:
-                            self.data_types[detector][label][prefix + md] = _data_types.tolist()
+                        usage = np.array(self.data_types[detector][label][prefix + md])
+                        self.data_types[detector][label][prefix + md] = (
+                            usage * _detector["redundancy"][md]
+                        ).tolist()
 
     def dependency_exists(self, data_type="raw_records"):
         """Returns a boolean for whether the dependency exists in rucio and is accessible.

--- a/outsource/meta.py
+++ b/outsource/meta.py
@@ -124,15 +124,12 @@ LED_MODES = {
 
 
 def get_clean_per_chunk_data_types(context):
-    """
-    Remove data_types that are not registered at all
-    """
+    """Remove data_types that are not registered at all."""
     return [dt for dt in PER_CHUNK_DATA_TYPES if dt in context._plugin_class_registry]
 
+
 def get_clean_detector_data_types(context):
-    """
-    Remove data_types that are not registered at all from the list of possible data_types
-    """
+    """Remove data_types that are not registered at all from the list of possible data_types."""
 
     clean_detector_data_types = {}
     for detector, detector_dict in DETECTOR_DATA_TYPES.items():

--- a/outsource/meta.py
+++ b/outsource/meta.py
@@ -121,3 +121,23 @@ LED_MODES = {
     "tpc_pmtgain": ["led_calibration"],
     "tpc_commissioning_pmtap": ["afterpulses"],
 }
+
+
+def get_clean_per_chunk_data_types(context):
+    """
+    Remove data_types that are not registered at all
+    """
+    return [dt for dt in PER_CHUNK_DATA_TYPES if dt in context._plugin_class_registry]
+
+def get_clean_detector_data_types(context):
+    """
+    Remove data_types that are not registered at all from the list of possible data_types
+    """
+
+    clean_detector_data_types = {}
+    for detector, detector_dict in DETECTOR_DATA_TYPES.items():
+        clean_detector_data_types[detector] = detector_dict.copy()
+        clean_detector_data_types[detector]["possible"] = [
+            dt for dt in detector_dict["possible"] if dt in context._plugin_class_registry
+        ]
+    return clean_detector_data_types

--- a/outsource/submitter.py
+++ b/outsource/submitter.py
@@ -573,7 +573,9 @@ class Submitter:
             )
 
         desired_sites, requirements = self.get_rse_sites(dbcfg, rses, per_chunk=True)
-        desired_sites_for_us, requirements_for_us = self.get_rse_sites(dbcfg, ["UC_OSG_USERDISK"], per_chunk=False)
+        desired_sites_for_us, requirements_for_us = self.get_rse_sites(
+            dbcfg, ["UC_OSG_USERDISK"], per_chunk=False
+        )
 
         # Set up the combine job first -
         # we can then add to that job inside the chunk file loop

--- a/outsource/utils.py
+++ b/outsource/utils.py
@@ -272,7 +272,7 @@ def per_chunk_storage_root_data_type(st, run_id, data_type):
     per_chunk_data_types = get_clean_per_chunk_data_types(st)
 
     # First filter on the existing and registered data_types
-    per_chunk_data_types = [d for d in per_chunk_data_types if d in st._plugin_class_registry]    
+    per_chunk_data_types = [d for d in per_chunk_data_types if d in st._plugin_class_registry]
 
     if data_type in st._get_plugins(per_chunk_data_types, "0"):
         # find the root data_type

--- a/outsource/utils.py
+++ b/outsource/utils.py
@@ -7,7 +7,7 @@ import strax
 import straxen
 import cutax
 
-from outsource.meta import DETECTOR_DATA_TYPES, PER_CHUNK_DATA_TYPES
+from outsource.meta import get_clean_detector_data_types, get_clean_per_chunk_data_types
 
 
 logger = setup_logger("outsource", uconfig.get("Outsource", "logging_level", fallback="WARNING"))
@@ -92,8 +92,8 @@ def get_runlist(
     basic_queries = []
     basic_queries_has_raw = []
     basic_queries_to_save = []
-
-    for det, det_info in DETECTOR_DATA_TYPES.items():
+    detector_data_types = get_clean_detector_data_types(st)
+    for det, det_info in detector_data_types.items():
         if detector != "all" and detector != det:
             logger.warning(f"Skipping {det} data")
             continue
@@ -222,8 +222,9 @@ def get_possible_dependencies(st, lower=False):
         return st.root_data_types
 
     # Get the data_types in the same plugin of PER_CHUNK_DATA_TYPES
+    per_chunk_data_types = get_clean_per_chunk_data_types(st)
     possible_dependencies = chain.from_iterable(
-        st._plugin_class_registry[d]().provides for d in PER_CHUNK_DATA_TYPES
+        st._plugin_class_registry[d]().provides for d in per_chunk_data_types
     )
     # Add the root_data_types because PER_CHUNK_DATA_TYPES depends on them
     possible_dependencies = set(possible_dependencies) | st.root_data_types
@@ -241,9 +242,10 @@ def get_to_save_data_types(st, data_types, rm_lower=False):
         [k for k, v in plugins.items() if v.save_when[k] == strax.SaveWhen.ALWAYS]
     )
     possible_data_types -= st.root_data_types
+    per_chunk_data_types = get_clean_per_chunk_data_types(st)
     if rm_lower:
         # Remove all data_types to be saved when processing PER_CHUNK_DATA_TYPES
-        possible_data_types -= get_to_save_data_types(st, PER_CHUNK_DATA_TYPES, False)
+        possible_data_types -= get_to_save_data_types(st, per_chunk_data_types, False)
     return possible_data_types
 
 
@@ -265,7 +267,14 @@ def per_chunk_storage_root_data_type(st, run_id, data_type):
     root data_type of the data_type. For exmaple, it will return "raw_records" for "peaklets".
 
     """
-    if data_type in st._get_plugins(PER_CHUNK_DATA_TYPES, "0"):
+
+    # Filter out the data_types that are not in the registered plugins
+    per_chunk_data_types = get_clean_per_chunk_data_types(st)
+
+    # First filter on the existing and registered data_types
+    per_chunk_data_types = [d for d in per_chunk_data_types if d in st._plugin_class_registry]    
+
+    if data_type in st._get_plugins(per_chunk_data_types, "0"):
         # find the root data_type
         root_data_types = list(set(st.get_dependencies(data_type)) & st.root_data_types)
         if len(root_data_types) > 1:
@@ -298,6 +307,7 @@ def get_processing_order(st, data_types, rm_lower=False):
     _data_types &= get_to_save_data_types(st, tuple(_data_types), rm_lower=rm_lower)
     if rm_lower:
         # Remove all data_types to be saved when processing PER_CHUNK_DATA_TYPES
-        _data_types -= set(get_processing_order(st, PER_CHUNK_DATA_TYPES, False))
+        per_chunk_data_types = get_clean_per_chunk_data_types(st)
+        _data_types -= set(get_processing_order(st, per_chunk_data_types, False))
     _data_types = sorted(_data_types, key=lambda x: st.tree_levels[x]["order"])
     return _data_types


### PR DESCRIPTION
Hey all, 

here some small modifications to outsource from a small test I tried to run (without knowing much). 

- Allow for unregistered plugins in the hardcoded  PER_CHUNK_DATA_TYPES, DETECTOR_DATA_TYPES: because some plugins can be non registered in the used straxen version (I had it now for the peaklet posrec for example), I now filter them and simply drop the extra plugins. 
- Update the RSE desired sites list, as all the nikhef and surfsara locations are basically interchangeable (I use now only NL ase country requirement - tested and works.)
- Update comment on desired sites list: this is something that constrains where we can run the jobs based on the RSE that we put in the xenon config. I thing we could just get rid of this functionality probably. 
- When assigning resources the datatypes tolist() was ginving error if the value is just one float, now handles this case. 
- Added stream output to see err and out files live, but does not always work. 
- Cutax tar files are saved with - and not with . , so I am replacing that in the version
- The combine job should always run in the US as the data is on davs staging site anyway.

Some of these changes might now be really what we want as a solution, so please just consider it as a proposal :) 

Ciao,
Carlo