### PR TITLE
Lower memory usage of lower level processing

### DIFF
--- a/outsource/config.py
+++ b/outsource/config.py
@@ -25,6 +25,8 @@ COMBINE_CPUS = uconfig.getint("Outsource", "combine_cpus", fallback=1)
 UPPER_CPUS = uconfig.getint("Outsource", "upper_cpus", fallback=1)
 EU_SEPARATE = uconfig.getboolean("Outsource", "eu_separate", fallback=False)
 
+MAX_MEMORY = 30_000
+
 db = DB()
 coll = xent_collection()
 
@@ -425,6 +427,11 @@ class RunConfig:
                         if prefix + md not in self.data_types[detector][label]:
                             continue
                         usage = np.array(self.data_types[detector][label][prefix + md])
+                        if md == "memory" and usage.max() > MAX_MEMORY:
+                            raise ValueError(
+                                f"Memory usage {usage.max()} is too high for "
+                                f"{detector} {label} {prefix + md}!"
+                            )
                         self.data_types[detector][label][prefix + md] = (
                             usage * _detector["redundancy"][md]
                         ).tolist()

--- a/outsource/meta.py
+++ b/outsource/meta.py
@@ -55,7 +55,7 @@ DETECTOR_DATA_TYPES = {
             "afterpulses": None,
         },
         "memory": {
-            "lower": [6.0, 1.0e3],
+            "lower": [3.2, 1.2e3],
             "combine": [0.0, 2.0e3],
             "upper": [0.075, 3.5e3],
         },


### PR DESCRIPTION
Also add a upper limit of memory usage

Depends on

1. https://github.com/AxFoundation/strax/pull/942 + https://github.com/XENONnT/straxen/pull/1508
2. https://github.com/AxFoundation/strax/pull/943

After these optimizations, https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:straxen:optimize_outsource_resources#optimized_memory_usage is achieved.

<img width="969" alt="image" src="https://github.com/user-attachments/assets/51dd3335-a349-4724-9f84-45c930a41912" />
