### PR TITLE
Set special memory usage for LED calibration runs

### DIFF
--- a/outsource/meta.py
+++ b/outsource/meta.py
@@ -117,9 +117,18 @@ DETECTOR_DATA_TYPES = {
 
 # LED calibration modes have particular data_type we care about
 LED_MODES = {
-    "tpc_pmtap": ["afterpulses"],
-    "tpc_pmtgain": ["led_calibration"],
-    "tpc_commissioning_pmtap": ["afterpulses"],
+    "tpc_pmtap": {
+        "possible": ["afterpulses"],
+        "memory": None,
+    },
+    "tpc_pmtgain": {
+        "possible": ["led_calibration"],
+        "memory": [7.0, 0.8e3],
+    },
+    "tpc_commissioning_pmtap": {
+        "possible": ["afterpulses"],
+        "memory": None,
+    },
 }
 
 


### PR DESCRIPTION
But the coefficients `[k, b] = [7.0, 0.8e3]` are a bit high. It would be good to optimize the memory usage so that 7.0 reduces to ~4.

Reference: https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:straxen:optimize_outsource_resources#memory_usage_for_led_calibration_runs