### PR TITLE
Add constraint for `SURFSARA2_USERDISK`

### DIFF
--- a/outsource/config.py
+++ b/outsource/config.py
@@ -63,6 +63,7 @@ class RunConfig:
         "NIKHEF2_USERDISK": {"site": "NIKHEF", "expr": 'GLIDEIN_Site == "NIKHEF"'},
         "NIKHEF_USERDISK": {"site": "NIKHEF", "expr": 'GLIDEIN_Site == "NIKHEF"'},
         "SURFSARA_USERDISK": {"site": "SURFsara", "expr": 'GLIDEIN_Site == "SURFsara"'},
+        "SURFSARA2_USERDISK": {"site": "SURFsara", "expr": 'GLIDEIN_Site == "SURFsara"'},
         "WEIZMANN_USERDISK": {"site": "Weizmann", "expr": 'GLIDEIN_Site == "Weizmann"'},
         "SDSC_USERDISK": {"expr": 'GLIDEIN_ResourceName == "SDSC-Expanse"'},
         "SDSC_NSDF_USERDISK": {"expr": 'GLIDEIN_Country == "US"'},


### PR DESCRIPTION
Somehow if these constraints are not added, the rucio `raw_records` will be invisible, e.g. `063518`.