### PR TITLE
Piecewise function for NV disk usage again

### DIFF
--- a/outsource/meta.py
+++ b/outsource/meta.py
@@ -71,7 +71,7 @@ DETECTOR_DATA_TYPES = {
         "raw": "raw_records_nv",
         "per_chunk": True,
         "possible": ["hitlets_nv", "events_nv", "event_positions_nv", "event_waveform_nv"],
-        "keep_chunks": straxen.nVETORecorder.takes_config["keep_n_chunks_for_monitoring"].default,
+        "keep_seconds": straxen.nVETORecorder.takes_config["keep_n_seconds_for_monitoring"].default,
         "rate": {
             "lone_raw_record_statistics_nv": [0, 0],
             "raw_records_coin_nv": [1.0, 0.02],


### PR DESCRIPTION
Be compatible with https://github.com/XENONnT/straxen/blob/bf6e7535912ced9bfa61d90b182086716a606267/straxen/plugins/raw_records_coin_nv/nveto_recorder.py#L82.

Similar to https://github.com/XENONnT/outsource/pull/257.