### PR TITLE
Add special input path for combine-only job

### DIFF
--- a/outsource/submitter.py
+++ b/outsource/submitter.py
@@ -115,7 +115,8 @@ class Submitter:
         self.scratch_dir = os.path.join(self.workflow_dir, "scratch")
 
         # All submitters need to make tarballs
-        self.make_tarballs()
+        if not (self.relay and self.debug):
+            self.make_tarballs()
 
     @property
     def runlist(self):


### PR DESCRIPTION
When no per-chunk processing is needed, the combine job depends on nothing. So that is a combine-only workflow. The per-chnk results should already be in `strax_data_osg_per_chunk`.